### PR TITLE
fix: add log index to index transfer records

### DIFF
--- a/components/ERC20TransferList.tsx
+++ b/components/ERC20TransferList.tsx
@@ -49,7 +49,7 @@ const TransferList: React.FC<{
           <TableBody>
             {+list.totalCount ? (
               list.txs.map(item => (
-                <TableRow key={item.hash + item.from + item.to}>
+                <TableRow key={item.hash + item.logIndex}>
                   <TableCell>
                     <Stack direction="row" alignItems="center">
                       <TxStatusIcon status={item.status} isSuccess={item.isSuccess} />

--- a/components/SimpleERC20TransferList.tsx
+++ b/components/SimpleERC20TransferList.tsx
@@ -46,7 +46,7 @@ const SimpleTransferList: React.FC<{
           <TableBody>
             {+list.totalCount ? (
               list.txs.map(item => (
-                <TableRow key={item.hash + item.from + item.to}>
+                <TableRow key={item.hash + item.logIndex}>
                   <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
                     <NextLink href={`/account/${item.from}`}>
                       <Link href={`/account/${item.from}`} underline="none" color="secondary" className="mono-font">

--- a/utils/api/txs.ts
+++ b/utils/api/txs.ts
@@ -60,6 +60,7 @@ interface Erc20Raw {
   udt_id: number
   udt_symbol: string
   udt_name: string
+  log_index: number
 }
 
 interface Erc20Parsed {
@@ -73,6 +74,7 @@ interface Erc20Parsed {
   transferValue: string
   udtId: number
   udtSymbol: string
+  logIndex: number
 }
 
 export const getTxListRes = (txListRes: {
@@ -128,6 +130,7 @@ export const getERC20TransferListRes = (list: {
     transferValue: tx.transfer_value,
     udtId: tx.udt_id,
     udtSymbol: tx.udt_symbol,
+    logIndex: tx.log_index,
   })),
 })
 export const fetchERC20TransferList = (


### PR DESCRIPTION
`item.hash + item.from + item.to` cannot differentiate erc20 transfers because multiple erc20 transfers can be included in a single transaction and send from/to the same addresses, thus they share the same `item.hash + item.from + item.to`, adding `log_index` to differentiate them.