### PR TITLE
Revert "feat: set ckb decimal 18"

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -9,7 +9,7 @@ export const GW_VERSION = +(process.env.NEXT_PUBLIC_GW_VERSION || 0)
 
 export const IMG_URL = '/icons/'
 export const PAGE_SIZE = 20
-export const CKB_DECIMAL = 10 ** 18
+export const CKB_DECIMAL = 100_000_000
 export const SEARCH_FIELDS = 'block hash/txn hash/lockhash/ETH address/token name/token symbol'
 export const WS_ENDPOINT = process.env.NEXT_PUBLIC_WS_URL
 export const MAINNET_HOSTNAME = process.env.NEXT_PUBLIC_MAINNET_EXPLORER_HOSTNAME


### PR DESCRIPTION
Reverts Magickbase/godwoken-explorer-ui#182

This commit misunderstood the design of CKB in godwoken.

There are two kinds of `CKB` in fact.

The one deposited from layer1 and minted as layer2 bridged token `CKB`, has decimal 8.
The other one is used as transaction fee in layer2 transaction, named `gCKB`, has decimal 18.

`CKB_DECIMAL` is used with `CKB` but not `gCKB`, so it should be intact.

Ref: https://github.com/Magickbase/godwoken_explorer/issues/529