### PR TITLE
fix: hide contract address if its length is incorrect

### DIFF
--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -64,6 +64,7 @@ type RawTx = Parameters<typeof getTxRes>[0]
 type ParsedTx = ReturnType<typeof getTxRes>
 
 type State = ParsedTx & Partial<{ transferList: ParsedTransferList }>
+const ADDR_LENGTH = 42
 
 const Tx = (initState: State) => {
   const [tx, setTx] = useState(initState)
@@ -173,7 +174,7 @@ const Tx = (initState: State) => {
       label: tx.toAlias ? 'interactedContract' : 'to',
       value: <Address address={tx.to} alias={tx.toAlias} />,
     },
-    tx.contractAddress
+    tx.contractAddress?.length === ADDR_LENGTH
       ? {
           label: 'deployed_contract',
           value: <Address address={tx.contractAddress} alias={tx.contractAddress} />,


### PR DESCRIPTION
Ref: https://github.com/Magickbase/godwoken_explorer/issues/549#issuecomment-1139225837

Before:
![image](https://user-images.githubusercontent.com/7271329/171082970-9ce7b110-0dda-46cd-8afb-f282b3c676d4.png)

After:
![image](https://user-images.githubusercontent.com/7271329/171082984-d5eac3a2-885c-4b15-a586-d04cea1edf86.png)
