### PR TITLE
fix: add unit in tooltips of charts

### DIFF
--- a/pages/charts.tsx
+++ b/pages/charts.tsx
@@ -80,7 +80,9 @@ const Charts = (initState: State) => {
                         tick={{ fontSize: 12 }}
                       />
                     ))}
-                    <Tooltip />
+                    {keys.map(({ key, unit }) => (
+                      <Tooltip key={key} formatter={value => (unit ? `${value} ${unit}` : value)} />
+                    ))}
                     <Legend />
                     <Brush height={20} tickFormatter={() => ''} stroke={theme.palette.primary.light}>
                       <AreaChart height={30} data={charts.dailyData}>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7271329/172826114-cb5b1f3a-5547-4ef5-b637-c53b29dc7e5e.png)
After:
![image](https://user-images.githubusercontent.com/7271329/172826136-b48c311a-6be2-460b-a876-866fa4fdd694.png)
