### PR TITLE
feat: mark fast withdrawal

### DIFF
--- a/components/BridgedRecordList.tsx
+++ b/components/BridgedRecordList.tsx
@@ -13,7 +13,8 @@ import {
   Link,
   Tooltip,
 } from '@mui/material'
-import { OpenInNew as OpenInNewIcon } from '@mui/icons-material'
+import { OpenInNew as OpenInNewIcon, Bolt as FastWithdrawalIcon } from '@mui/icons-material'
+import { yellow } from '@mui/material/colors'
 import BigNumber from 'bignumber.js'
 
 import Address from 'components/TruncatedAddress'
@@ -46,7 +47,20 @@ const BridgedRecordList: React.FC<{
             {+list.meta.total ? (
               list.records.map(r => (
                 <TableRow key={r.layer1.output.hash + r.layer1.output.index}>
-                  <TableCell sx={{ whiteSpace: 'nowrap', fontSize: { xs: 12, md: 14 } }}>{t(r.type)}</TableCell>
+                  <TableCell>
+                    <Stack
+                      direction="row"
+                      sx={{ whiteSpace: 'nowrap', fontSize: { xs: 12, md: 14 } }}
+                      alignItems="center"
+                    >
+                      {r.isFastWithdrawal ? (
+                        <Tooltip title={t(`fast-withdrawal`)} placement="top">
+                          <FastWithdrawalIcon sx={{ color: yellow[700], fontSize: 20 }} />
+                        </Tooltip>
+                      ) : null}
+                      {t(r.type)}
+                    </Stack>
+                  </TableCell>
                   <TableCell sx={{ fontSize: { xs: 12, md: 14 }, whiteSpace: 'nowrap' }}>
                     {`${new BigNumber(r.value ?? '0').toFormat()} ${r.token.symbol ?? ''}`}
                   </TableCell>

--- a/public/locales/en-US/list.json
+++ b/public/locales/en-US/list.json
@@ -24,8 +24,6 @@
   "gas_used": "gas used",
   "gas_limit": "gas limit",
   "rank": "rank",
-  "address": "address",
-  "balance": "balance",
   "percentage": "percentage",
   "txCount": "Txns",
   "contract_name": "contract name",
@@ -36,5 +34,6 @@
   "latest25ContractEvents": "Latest 25 Contract Events",
   "logs": "Logs",
   "eventsFilterPlaceholder": "Filter by BlockNo Or Topic0",
-  "filterEventBy": "Apply filter by {{filter}}"
+  "filterEventBy": "Apply filter by {{filter}}",
+  "fast-withdrawal": "Fast withdrawal"
 }

--- a/public/locales/zh-CN/list.json
+++ b/public/locales/zh-CN/list.json
@@ -24,8 +24,6 @@
   "gas_used": "gas 消耗",
   "gas_limit": "gas 上限",
   "rank": "排序",
-  "address": "地址",
-  "balance": "余额",
   "percentage": "百分比",
   "txCount": "交易数量",
   "contract_name": "合约名称",
@@ -36,5 +34,6 @@
   "latest25ContractEvents": "显示最近 25 条合约事件",
   "logs": "日志",
   "eventsFilterPlaceholder": "输入区块号或者 Topic0 进行筛选",
-  "filterEventBy": "筛选 {{filter}} 的事件"
+  "filterEventBy": "筛选 {{filter}} 的事件",
+  "fast-withdrawal": "快速提取"
 }

--- a/utils/api/bridged.ts
+++ b/utils/api/bridged.ts
@@ -29,6 +29,7 @@ export interface Raw {
     value: string
     state: BridgedState
     capacity: string | null
+    is_fast_withdrawal: boolean
   }>
 }
 
@@ -54,6 +55,7 @@ export interface Parsed {
     value: string
     state: BridgedState
     capacity: string | null
+    isFastWithdrawal: boolean
   }>
   meta: Record<'page' | 'total', string>
 }
@@ -84,6 +86,7 @@ export const getBridgedRecordListRes = (list: Raw): Parsed => ({
     value: r.value,
     state: r.state,
     capacity: r.capacity,
+    isFastWithdrawal: r.is_fast_withdrawal ?? false,
   })),
 })
 export const fetchBridgedRecordList = (


### PR DESCRIPTION
This PR adds a `fast withdrawal` icon before bridge records that transfer assets from godwoken v0 to godwoken v1 by `fast-withdraw`
![image](https://user-images.githubusercontent.com/7271329/174240050-b75bacd1-f3ce-4509-aaf5-9f8a8f21bad5.png)

Ref: https://github.com/Magickbase/godwoken_explorer/issues/553
