### PR TITLE
feat: use graphql to get token transfer list in account/token page

### DIFF
--- a/components/ERC20TransferList.tsx
+++ b/components/ERC20TransferList.tsx
@@ -13,17 +13,105 @@ import {
   Link,
   Tooltip,
 } from '@mui/material'
-import BigNumber from 'bignumber.js'
+import { gql } from 'graphql-request'
 import TxStatusIcon from './TxStatusIcon'
 import Address from 'components/TruncatedAddress'
-import Pagination from 'components/Pagination'
-import { timeDistance, getERC20TransferListRes } from 'utils'
+import Pagination from 'components/SimplePagination'
+import { timeDistance, getBlockStatus, GraphQLSchema, client, formatAmount } from 'utils'
 
-type ParsedTransferList = ReturnType<typeof getERC20TransferListRes>
+export type TransferListProps = {
+  token_transfers: {
+    entries: Array<{
+      amount: string
+      transaction_hash: string
+      log_index: number
+      polyjuice: Pick<GraphQLSchema.Polyjuice, 'status'>
+      from_address: string
+      to_address: string
+      block: Nullable<Pick<GraphQLSchema.Block, 'number' | 'timestamp' | 'status'>>
+      udt: Nullable<Pick<GraphQLSchema.Udt, 'decimal' | 'symbol' | 'id'>>
+    }>
+    metadata: GraphQLSchema.PageMetadata
+  }
+}
 
-const TransferList: React.FC<{
-  list: ParsedTransferList
-}> = ({ list }) => {
+const transferListQuery = gql`
+  query (
+    $from_address: String
+    $to_address: String
+    $start_block_number: Int
+    $end_block_number: Int
+    $before: String
+    $after: String
+    $combine_from_to: Boolean
+    $token_contract_address_hash: String
+  ) {
+    token_transfers(
+      input: {
+        from_address: $from_address
+        to_address: $to_address
+        start_block_number: $start_block_number
+        end_block_number: $end_block_number
+        before: $before
+        after: $after
+        combine_from_to: $combine_from_to
+        token_contract_address_hash: $token_contract_address_hash
+      }
+    ) {
+      entries {
+        amount
+        transaction_hash
+        log_index
+        polyjuice {
+          status
+        }
+        from_address
+        to_address
+        block {
+          number
+          timestamp
+          status
+        }
+        udt {
+          id
+          decimal
+          symbol
+        }
+      }
+
+      metadata {
+        total_count
+        before
+        after
+      }
+    }
+  }
+`
+
+interface Cursor {
+  before: string
+  after: string
+  start_block_number?: string
+  end_block_number?: string
+}
+
+interface BlockTransferListVariables extends Nullable<Cursor> {}
+
+interface AccountTransferListVariables extends Nullable<Cursor> {
+  from_address: string
+  to_address: string
+}
+
+interface TokenTransferListVariables extends Nullable<Cursor> {
+  token_contract_address_hash: string
+}
+
+type Variables = BlockTransferListVariables | AccountTransferListVariables | TokenTransferListVariables
+
+export const fetchTransferList = (variables: Variables) =>
+  client.request<TransferListProps>(transferListQuery, variables).then(data => data.token_transfers)
+
+const TransferList: React.FC<TransferListProps> = ({ token_transfers: { entries, metadata } }) => {
   const [t, { language }] = useTranslation('list')
   return (
     <Box sx={{ px: 1, py: 2 }}>
@@ -47,22 +135,25 @@ const TransferList: React.FC<{
             </TableRow>
           </TableHead>
           <TableBody>
-            {+list.totalCount ? (
-              list.txs.map(item => (
-                <TableRow key={item.hash + item.logIndex}>
+            {+metadata.total_count ? (
+              entries.map(item => (
+                <TableRow key={`${item.transaction_hash}-${item.log_index}`}>
                   <TableCell>
                     <Stack direction="row" alignItems="center">
-                      <TxStatusIcon status={item.status} isSuccess={item.isSuccess} />
-                      <Tooltip title={item.hash} placement="top">
+                      <TxStatusIcon
+                        status={getBlockStatus(item.block)}
+                        isSuccess={item.polyjuice.status === GraphQLSchema.PolyjuiceStatus.Succeed}
+                      />
+                      <Tooltip title={item.transaction_hash} placement="top">
                         <Box>
-                          <NextLink href={`/tx/${item.hash}`}>
-                            <Link href={`/tx/${item.hash}`} underline="none" color="secondary">
+                          <NextLink href={`/tx/${item.transaction_hash}`}>
+                            <Link href={`/tx/${item.transaction_hash}`} underline="none" color="secondary">
                               <Typography
                                 className="mono-font"
                                 overflow="hidden"
                                 sx={{ userSelect: 'none', fontSize: { xs: 12, md: 14 } }}
                               >
-                                {`${item.hash.slice(0, 8)}...${item.hash.slice(-8)}`}
+                                {`${item.transaction_hash.slice(0, 8)}...${item.transaction_hash.slice(-8)}`}
                               </Typography>
                             </Link>
                           </NextLink>
@@ -71,32 +162,40 @@ const TransferList: React.FC<{
                     </Stack>
                   </TableCell>
                   <TableCell>
-                    <NextLink href={`/block/${item.blockNumber}`}>
-                      <Link
-                        href={`/block/${item.blockNumber}`}
-                        underline="none"
-                        color="secondary"
-                        sx={{
-                          fontSize: {
-                            xs: 12,
-                            md: 14,
-                          },
-                        }}
-                      >
-                        {(+item.blockNumber).toLocaleString('en')}
-                      </Link>
-                    </NextLink>
+                    {item.block ? (
+                      <NextLink href={`/block/${item.block.number}`}>
+                        <Link
+                          href={`/block/${item.block.number}`}
+                          underline="none"
+                          color="secondary"
+                          sx={{
+                            fontSize: {
+                              xs: 12,
+                              md: 14,
+                            },
+                          }}
+                        >
+                          {item.block.number.toLocaleString('en')}
+                        </Link>
+                      </NextLink>
+                    ) : (
+                      t(`pending`)
+                    )}
                   </TableCell>
                   <TableCell sx={{ whiteSpace: 'nowrap', fontSize: { xs: 12, md: 14 } }}>
-                    <time dateTime={new Date(+item.timestamp).toISOString()}>
-                      {timeDistance(item.timestamp, language)}
-                    </time>
+                    {item.block ? (
+                      <time dateTime={new Date(item.block.timestamp).toISOString()}>
+                        {timeDistance(item.block.timestamp, language)}
+                      </time>
+                    ) : (
+                      t(`pending`)
+                    )}
                   </TableCell>
                   <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                    <Address address={item.from} size="normal" />
+                    <Address address={item.from_address} size="normal" />
                   </TableCell>
                   <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                    {item.to ? <Address address={item.to} size="normal" /> : null}
+                    <Address address={item.to_address} size="normal" />
                   </TableCell>
                   <TableCell sx={{ display: { xs: 'table-cell', md: 'none' } }}>
                     <Stack>
@@ -105,7 +204,7 @@ const TransferList: React.FC<{
                           fontSize={12}
                           sx={{ textTransform: 'capitalize', mr: 1, whiteSpace: 'nowrap' }}
                         >{`${t('from')}:`}</Typography>
-                        <Address leading={5} address={item.from} />
+                        <Address leading={5} address={item.from_address} />
                       </Stack>
 
                       <Stack direction="row" justifyContent="space-between">
@@ -113,14 +212,20 @@ const TransferList: React.FC<{
                           fontSize={12}
                           sx={{ textTransform: 'capitalize', mr: 1, whiteSpace: 'nowrap' }}
                         >{`${t('to')}:`}</Typography>
-                        {item.to ? <Address address={item.to} leading={5} /> : null}
+                        <Address address={item.to_address} leading={5} />
                       </Stack>
                     </Stack>
                   </TableCell>
                   <TableCell sx={{ fontSize: { xs: 12, md: 14 }, whiteSpace: 'nowrap' }}>
-                    {item.transferValue
-                      ? `${new BigNumber(item.transferValue).toFormat()} ${item.udtSymbol ?? ''}`
-                      : null}
+                    {item.udt.id ? (
+                      <NextLink href={`/token/${item.udt.id}`}>
+                        <Link href={`/token/${item.udt.id}`} underline="none" color="secondary">
+                          {formatAmount(item.amount, item.udt)}
+                        </Link>
+                      </NextLink>
+                    ) : (
+                      formatAmount(item.amount, item.udt)
+                    )}
                   </TableCell>
                 </TableRow>
               ))
@@ -134,7 +239,7 @@ const TransferList: React.FC<{
           </TableBody>
         </Table>
       </TableContainer>
-      <Pagination total={+list.totalCount} page={+list.page} />
+      <Pagination {...metadata} />
       <Stack direction="row-reverse">
         <Typography color="primary.light" variant="caption">
           {t(`last-n-records`, { n: `100k` })}

--- a/components/SimpleERC20TransferList.tsx
+++ b/components/SimpleERC20TransferList.tsx
@@ -222,6 +222,15 @@ const TransferList: React.FC<TransferListProps> = ({ token_transfers: { entries,
                     </Stack>
                   </TableCell>
                   <TableCell sx={{ whiteSpace: 'nowrap' }} title={item.udt.name}>
+                    {item.udt.id ? (
+                      <NextLink href={`/token/${item.udt.id}`}>
+                        <Link href={`/token/${item.udt.id}`} underline="none" color="secondary">
+                          {formatAmount(item.amount, item.udt)}
+                        </Link>
+                      </NextLink>
+                    ) : (
+                      formatAmount(item.amount, item.udt)
+                    )}
                     <NextLink href={`/token/${item.udt.id}`}>
                       <Link href={`/token/${item.udt.id}`} underline="none" color="secondary">
                         {formatAmount(item.amount, item.udt)}

--- a/components/TxList.tsx
+++ b/components/TxList.tsx
@@ -26,7 +26,7 @@ import TxStatusIcon from './TxStatusIcon'
 import Address from 'components/TruncatedAddress'
 import PageSize from 'components/PageSize'
 import Pagination from 'components/SimplePagination'
-import { timeDistance, GraphQLSchema, TxStatus, client, GCKB_DECIMAL, useFilterMenu } from 'utils'
+import { timeDistance, getBlockStatus, GraphQLSchema, client, GCKB_DECIMAL, useFilterMenu } from 'utils'
 
 export type TxListProps = {
   transactions: {
@@ -110,7 +110,7 @@ interface EthAccountTxListVariables extends Nullable<Cursor> {
 interface GwAccountTxListVariables extends Nullable<Cursor> {
   script_hash?: string | null
 }
-interface BlockTxListVariables extends Nullable<Cursor> {}
+interface BlockTxListVariables extends Nullable<Cursor> { }
 type Variables = Cursor | EthAccountTxListVariables | GwAccountTxListVariables | BlockTxListVariables
 
 export const fetchTxList = (variables: Variables) =>
@@ -118,20 +118,6 @@ export const fetchTxList = (variables: Variables) =>
     .request<TxListProps>(txListQuery, variables)
     .then(data => data.transactions)
     .catch(() => ({ entries: [], metadata: { before: null, after: null, total_count: 0 } }))
-
-const getBlockStatus = (block: Pick<GraphQLSchema.Block, 'status'> | null): TxStatus => {
-  switch (block?.status) {
-    case GraphQLSchema.BlockStatus.Committed: {
-      return 'committed'
-    }
-    case GraphQLSchema.BlockStatus.Finalized: {
-      return 'finalized'
-    }
-    default: {
-      return 'pending'
-    }
-  }
-}
 
 const FILTER_KEYS = ['block_from', 'block_to'] as const
 const TxList: React.FC<TxListProps & { maxCount?: string; pageSize?: number }> = ({

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -13,7 +13,7 @@ import AccountOverview, {
   AccountOverviewProps,
   PolyjuiceContract,
 } from 'components/AccountOverview'
-import ERC20TransferList from 'components/ERC20TransferList'
+import ERC20TransferList, { fetchTransferList, TransferListProps } from 'components/ERC20TransferList'
 import AssetList, { fetchUdtList, UdtList } from 'components/UdtList'
 import TxList, { TxListProps, fetchTxList } from 'components/TxList'
 import BridgedRecordList from 'components/BridgedRecordList'
@@ -22,9 +22,7 @@ import ContractEventsList from 'components/ContractEventsList'
 import {
   handleCopy,
   // useWS,
-  // getAccountRes,
   handleApiError,
-  getERC20TransferListRes,
   fetchERC20TransferList,
   getBridgedRecordListRes,
   fetchBridgedRecordList,
@@ -37,13 +35,12 @@ import {
 } from 'utils'
 import PageTitle from 'components/PageTitle'
 
-type ParsedTransferList = ReturnType<typeof getERC20TransferListRes>
 type ParsedBridgedRecordList = ReturnType<typeof getBridgedRecordListRes>
 
 type State = AccountOverviewProps &
   Partial<{
     txList: TxListProps['transactions']
-    transferList: ParsedTransferList
+    transferList: TransferListProps['token_transfers']
     bridgedRecordList: ParsedBridgedRecordList
     udtList: UdtList
     eventsList: ParsedEventLog[]
@@ -150,7 +147,7 @@ const Account = (initState: State) => {
               <TxList transactions={accountAndList.txList} maxCount="100k" />
             ) : null}
             {tab === 'erc20' && accountAndList.transferList ? (
-              <ERC20TransferList list={accountAndList.transferList} />
+              <ERC20TransferList token_transfers={accountAndList.transferList} />
             ) : null}
             {tab === 'bridged' && accountAndList.bridgedRecordList ? (
               <BridgedRecordList list={accountAndList.bridgedRecordList} />
@@ -220,7 +217,12 @@ export const getServerSideProps: GetServerSideProps<State, { id: string }> = asy
 
     const transferList =
       tab === 'erc20' && q.address
-        ? await fetchERC20TransferList({ eth_address: q.address, page: query.page as string })
+        ? await fetchTransferList({
+            from_address: q.address,
+            to_address: q.address,
+            before: before as string | null,
+            after: after as string | null,
+          })
         : null
     const bridgedRecordList =
       tab === 'bridged' && q.address

--- a/utils/convertors.ts
+++ b/utils/convertors.ts
@@ -20,7 +20,7 @@ export const formatDatetime = (datetime: number) => {
   return dayjs(datetime).format('YYYY/MM/DD HH:mm:ss')
 }
 
-export const timeDistance = (time: number, locale?: 'zh-CN' | 'en-US' | string) => {
+export const timeDistance = (time: Parameters<typeof dayjs>[0], locale?: 'zh-CN' | 'en-US' | string) => {
   dayjs.locale(locale?.toLowerCase())
   return dayjs(time).fromNow()
 }

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,4 +1,6 @@
 import { utils } from 'ethers'
+import type { TxStatus } from './api'
+import { GraphQLSchema } from './graphql'
 
 export const isEthAddress = (hash: string) => {
   try {
@@ -9,4 +11,18 @@ export const isEthAddress = (hash: string) => {
     // ignore
   }
   return false
+}
+
+export const getBlockStatus = (block: Pick<GraphQLSchema.Block, 'status'> | null): TxStatus => {
+  switch (block?.status) {
+    case GraphQLSchema.BlockStatus.Committed: {
+      return 'committed'
+    }
+    case GraphQLSchema.BlockStatus.Finalized: {
+      return 'finalized'
+    }
+    default: {
+      return 'pending'
+    }
+  }
 }


### PR DESCRIPTION
This PR is a complement to PR #219, which only update api of
token transfer list in transaction page

Account page preview: https://godwoken-explorer-pd225intt-nervosnet.vercel.app/account/0x0eaa4ad8452100dff831539d6392881b4c7d7649?tab=erc20

Token page preview: https://godwoken-explorer-pd225intt-nervosnet.vercel.app/token/6841