### PR TITLE
feat: display unknown account

### DIFF
--- a/components/UnknownAccount.tsx
+++ b/components/UnknownAccount.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'next-i18next'
+import { List, ListItem, ListItemText, ListSubheader, Divider, Typography } from '@mui/material'
+
+const User = ({ nonce }: { nonce: number }) => {
+  const [t] = useTranslation('account')
+
+  const fields = [
+    {
+      label: t(`type`),
+      value: <Typography variant="body2">Uknown</Typography>,
+    },
+    { label: t('nonce'), value: <Typography variant="body2">{nonce.toLocaleString('en')}</Typography> },
+  ]
+
+  return (
+    <List
+      subheader={
+        <ListSubheader component="div" sx={{ textTransform: 'capitalize', bgcolor: 'transparent' }}>
+          {t('basicInfo')}
+        </ListSubheader>
+      }
+      sx={{ textTransform: 'capitalize' }}
+    >
+      <Divider variant="middle" />
+      {fields.map(field => (
+        <ListItem key={field.label}>
+          <ListItemText primary={field.label} secondary={field.value} />
+        </ListItem>
+      ))}
+    </List>
+  )
+}
+
+export default User

--- a/public/locales/en-US/account.json
+++ b/public/locales/en-US/account.json
@@ -8,7 +8,8 @@
     "UDT": "Bridged Token Account",
     "POLYJUICE_CREATOR": "Polyjuice Creator Account",
     "META_CONTRACT": "Meta Contract Account",
-    "ETH_ADDR_REG": "Eth Addr Reg"
+    "ETH_ADDR_REG": "Eth Addr Reg",
+    "UNKNOWN": "Unknown"
   },
   "id": "account id",
   "nonce": "nonce",

--- a/public/locales/zh-CN/account.json
+++ b/public/locales/zh-CN/account.json
@@ -8,7 +8,8 @@
     "UDT": "桥接资产账户",
     "POLYJUICE_CREATOR": "Polyjuice Creator 账户",
     "META_CONTRACT": "Meta 合约账户",
-    "ETH_ADDR_REG": "Eth 地址注册账户"
+    "ETH_ADDR_REG": "Eth 地址注册账户",
+    "UNKNOWN": "未知账户"
   },
   "id": "账户 id",
   "nonce": "nonce",


### PR DESCRIPTION
This commit enables displaying a blank unknown account instead of
redirecting to a 404 not-found page when target account is not generated
on godwoken.

`0x44943241f6491d5f3fd833788ade6941967cb9e2` is a valid eth address but not created on godwoken so visiting `0x44943241f6491d5f3fd833788ade6941967cb9e2` leads to the 404 page. This commit adds a blank account page if `0x44943241f6491d5f3fd833788ade6941967cb9e2` account is not generated on godwoken.