### PR TITLE
feat: add export data button in some pages

### DIFF
--- a/components/DownloadMenu/index.tsx
+++ b/components/DownloadMenu/index.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useTranslation } from 'next-i18next'
+import { Button, Menu, MenuList, MenuItem, Link, Tooltip } from '@mui/material'
+import { Download as DownloadIcon } from '@mui/icons-material'
+import { API_ENDPOINT } from 'utils'
+
+interface DownloadMenuProps {
+  items: Array<Record<'label' | 'href', string>>
+}
+export const DOWNLOAD_HREF_LIST = {
+  accountTxList: (eth_address: string) => `${API_ENDPOINT}/txs?${new URLSearchParams({ eth_address, export: 'true' })}`,
+  accountBridgeRecordList: (eth_address: string) =>
+    `${API_ENDPOINT}/deposit_withdrawals?${new URLSearchParams({ eth_address, export: 'true' })}`,
+  accountTransferList: (eth_address: string) =>
+    `${API_ENDPOINT}/transfers?${new URLSearchParams({ eth_address, export: 'true' })}`,
+  udtHolderList: (udt_id: string) => `${API_ENDPOINT}/account_udts/${new URLSearchParams({ udt_id, export: 'true' })}`,
+  udtBridgeRecordList: (udt_id: string) =>
+    `${API_ENDPOINT}/deposit_withdrawals?${new URLSearchParams({ udt_id, export: 'true' })}`,
+  udtTransferList: (udt_address: string) =>
+    `${API_ENDPOINT}/transfers?${new URLSearchParams({ udt_address, export: 'true' })}`,
+  blockBridgeRecordList: (block_number: string) =>
+    `${API_ENDPOINT}/deposit_withdrawals?${new URLSearchParams({ block_number, export: 'true' })}`,
+  blockTxList: (block_hash: string) => `${API_ENDPOINT}/txs?${new URLSearchParams({ block_hash, export: 'true' })}`,
+  txTransferList: (tx_hash: string) => `${API_ENDPOINT}/transfers?${new URLSearchParams({ tx_hash, export: 'true' })}`,
+}
+
+const DownloadMenu: React.FC<DownloadMenuProps> = ({ items }) => {
+  const [t] = useTranslation('common')
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget)
+  }
+  const handleDismiss = () => setAnchorEl(null)
+
+  return (
+    <div>
+      <Tooltip title={t(`up_to_5k_records_will_be_exported`)} placement="bottom">
+        <Button variant="text" onClick={handleOpen} endIcon={<DownloadIcon />}>
+          {t('download')}
+        </Button>
+      </Tooltip>
+      <Menu
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={handleDismiss}
+        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <MenuList>
+          {items.map(item => (
+            <Link key={item.label} href={item.href} underline="none">
+              <MenuItem sx={{ minWidth: 100 }} onClick={handleDismiss}>
+                {item.label}
+              </MenuItem>
+            </Link>
+          ))}
+        </MenuList>
+      </Menu>
+    </div>
+  )
+}
+
+export default DownloadMenu

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -36,6 +36,7 @@ import {
   NotFoundException,
 } from 'utils'
 import PageTitle from 'components/PageTitle'
+import DownloadMenu, { DOWNLOAD_HREF_LIST } from 'components/DownloadMenu'
 
 type ParsedTransferList = ReturnType<typeof getERC20TransferListRes>
 type ParsedBridgedRecordList = ReturnType<typeof getBridgedRecordListRes>
@@ -81,6 +82,18 @@ const Account = (initState: State) => {
   //   [setAccount, account.ethAddr],
   // )
 
+  /* is script hash supported? */
+  const downloadItems = accountAndList.account.eth_address
+    ? [
+        { label: t('transactionRecords'), href: DOWNLOAD_HREF_LIST.accountTxList(accountAndList.account.eth_address) },
+        { label: t('ERC20Records'), href: DOWNLOAD_HREF_LIST.accountTransferList(accountAndList.account.eth_address) },
+        {
+          label: t('bridgedRecords'),
+          href: DOWNLOAD_HREF_LIST.accountBridgeRecordList(accountAndList.account.eth_address),
+        },
+      ]
+    : []
+
   const handleAddressCopy = async () => {
     await handleCopy(id)
     setIsCopied(true)
@@ -93,17 +106,20 @@ const Account = (initState: State) => {
     <>
       <SubpageHead subtitle={title} />
       <Container sx={{ py: 6 }}>
-        <PageTitle>
-          <Stack direction="row" alignItems="center">
-            <Typography variant="inherit" overflow="hidden" textOverflow="ellipsis" noWrap>
-              {title}
-            </Typography>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <PageTitle>
+            <Stack direction="row" alignItems="center">
+              <Typography variant="inherit" overflow="hidden" textOverflow="ellipsis" noWrap>
+                {title}
+              </Typography>
 
-            <IconButton aria-label="copy" onClick={handleAddressCopy}>
-              <CopyIcon fontSize="inherit" />
-            </IconButton>
-          </Stack>
-        </PageTitle>
+              <IconButton aria-label="copy" onClick={handleAddressCopy}>
+                <CopyIcon fontSize="inherit" />
+              </IconButton>
+            </Stack>
+          </PageTitle>
+          <DownloadMenu items={downloadItems} />
+        </Stack>
         <Stack spacing={2}>
           <AccountOverview
             account={accountAndList.account}

--- a/pages/block/[id].tsx
+++ b/pages/block/[id].tsx
@@ -27,6 +27,7 @@ import SubpageHead from 'components/SubpageHead'
 import TxList, { TxListProps, fetchTxList } from 'components/TxList'
 import BridgedRecordList from 'components/BridgedRecordList'
 import PageTitle from 'components/PageTitle'
+import DownloadMenu, { DOWNLOAD_HREF_LIST } from 'components/DownloadMenu'
 import {
   fetchBlock,
   handleApiError,
@@ -74,6 +75,11 @@ const Block = (initState: State) => {
     },
     [setBlock, block.number],
   )
+
+  const downloadItems = [
+    { label: t('transactionRecords'), href: DOWNLOAD_HREF_LIST.blockTxList(block.hash) },
+    { label: t('bridgedRecords'), href: DOWNLOAD_HREF_LIST.blockBridgeRecordList(block.number.toString()) },
+  ]
 
   const handleHashCopy = async () => {
     await handleCopy(block.hash)
@@ -256,7 +262,10 @@ const Block = (initState: State) => {
     <>
       <SubpageHead subtitle={title} />
       <Container sx={{ py: 6 }}>
-        <PageTitle>{title}</PageTitle>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <PageTitle>{title}</PageTitle>
+          <DownloadMenu items={downloadItems} />
+        </Stack>
         <Stack spacing={2}>
           <Paper>
             <List sx={{ textTransform: 'capitalize' }}>

--- a/pages/token/[id].tsx
+++ b/pages/token/[id].tsx
@@ -26,6 +26,7 @@ import ERC20TransferList from 'components/ERC20TransferList'
 import BridgedRecordList from 'components/BridgedRecordList'
 import TokenHolderList from 'components/TokenHolderList'
 import Address from 'components/AddressInHalfPanel'
+import DownloadMenu, { DOWNLOAD_HREF_LIST } from 'components/DownloadMenu'
 import {
   handleApiError,
   fetchToken,
@@ -59,6 +60,15 @@ const Token = ({ token, transferList, bridgedRecordList, tokenHolderList }: Prop
     push,
     query: { tab = 'transfers' },
   } = useRouter()
+
+  const downloadItems = [
+    { label: t('transferRecords'), href: DOWNLOAD_HREF_LIST.udtTransferList(token.address) },
+    token.type === 'bridge'
+      ? { label: t('bridgedRecords'), href: DOWNLOAD_HREF_LIST.udtBridgeRecordList(token.id.toString()) }
+      : null,
+    { label: t('tokenHolders'), href: DOWNLOAD_HREF_LIST.udtHolderList(token.id.toString()) },
+  ].map(i => i)
+
   const tokenInfo = [
     { label: 'decimal', value: <Typography variant="body2">{token.decimal || '-'}</Typography> },
     { label: 'type', value: <Typography variant="body2">{t(token.type)}</Typography> },
@@ -118,26 +128,30 @@ const Token = ({ token, transferList, bridgedRecordList, tokenHolderList }: Prop
     <>
       <SubpageHead subtitle={`${t('token')} ${token.name || token.symbol || '-'}`} />
       <Container sx={{ py: 6 }}>
-        <PageTitle>
-          <Stack direction="row" alignItems="center">
-            <Avatar
-              src={token.icon ?? null}
-              sx={{ bgcolor: token.icon ? '#f0f0f0' : nameToColor(token.name ?? ''), mr: 2 }}
-            >
-              {token.name?.[0] ?? '?'}
-            </Avatar>
-            <Typography variant="h5" fontWeight="inherit">
-              {token.name || '-'}
-            </Typography>
-            {token.symbol ? (
-              <Typography
-                fontWeight="inherit"
-                color="primary.light"
-                whiteSpace="pre"
-              >{` (${token.symbol})`}</Typography>
-            ) : null}
-          </Stack>
-        </PageTitle>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <PageTitle>
+            <Stack direction="row" alignItems="center">
+              <Avatar
+                src={token.icon ?? null}
+                sx={{ bgcolor: token.icon ? '#f0f0f0' : nameToColor(token.name ?? ''), mr: 2 }}
+              >
+                {token.name?.[0] ?? '?'}
+              </Avatar>
+              <Typography variant="h5" fontWeight="inherit">
+                {token.name || '-'}
+              </Typography>
+              {token.symbol ? (
+                <Typography
+                  fontWeight="inherit"
+                  color="primary.light"
+                  whiteSpace="pre"
+                >{` (${token.symbol})`}</Typography>
+              ) : null}
+            </Stack>
+          </PageTitle>
+
+          <DownloadMenu items={downloadItems} />
+        </Stack>
         <Stack spacing={2}>
           <Paper>
             <Grid container spacing={2}>

--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -42,6 +42,7 @@ import PageTitle from 'components/PageTitle'
 import Address from 'components/AddressInHalfPanel'
 import TransferList, { fetchTransferList, TransferListProps } from 'components/SimpleERC20TransferList'
 import TxLogsList from 'components/TxLogsList'
+import DownloadMenu, { DOWNLOAD_HREF_LIST } from 'components/DownloadMenu'
 import {
   formatDatetime,
   fetchTx,
@@ -75,6 +76,8 @@ const Tx = (initState: State) => {
     query: { tab = 'erc20' },
   } = useRouter()
   const [t] = useTranslation('tx')
+
+  const downloadItems = [{ label: t('ERC20Records'), href: DOWNLOAD_HREF_LIST.txTransferList(tx.hash) }]
 
   const decodedInput = useMemo(() => {
     if (initState.contractAbi && initState.contractAbi.length && initState.input) {
@@ -296,7 +299,10 @@ const Tx = (initState: State) => {
     <>
       <SubpageHead subtitle={`${title} ${tx.hash}`} />
       <Container sx={{ pb: 6 }}>
-        <PageTitle>{title}</PageTitle>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <PageTitle>{title}</PageTitle>
+          <DownloadMenu items={downloadItems} />
+        </Stack>
         <Stack spacing={2}>
           <Paper>
             <Grid container>

--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -34,5 +34,7 @@
     "records": "records"
   },
   "view_all_blocks": "View all blocks",
-  "view_all_transactions": "View all transactions"
+  "view_all_transactions": "View all transactions",
+  "download": "download",
+  "up_to_5k_records_will_be_exported": "Up to 5,000 records will be downloaded"
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -34,5 +34,7 @@
     "records": "条记录"
   },
   "view_all_blocks": "查看所有区块",
-  "view_all_transactions": "查看所有交易"
+  "view_all_transactions": "查看所有交易",
+  "download": "下载",
+  "up_to_5k_records_will_be_exported": "最多可下载 5,000 条记录"
 }


### PR DESCRIPTION
1. export tx list, transfer list, bridged record list in account page
2. export tx list, bridged record list in block page
3. export transfer list, bridged record list, holder list in token page
4. export transfer list in tx page

https://user-images.githubusercontent.com/7271329/176503022-7e18386f-9132-4630-8d2c-7b47b35f4b02.mov

