### PR TITLE
feat: use pCKB instead of pCKB.gw|fb.eth in label and table header

### DIFF
--- a/components/AccountOverview.tsx
+++ b/components/AccountOverview.tsx
@@ -9,7 +9,7 @@ import SmartContract from 'components/SmartContract'
 import Polyjuice from 'components/Polyjuice'
 import SUDT from 'components/SUDT'
 import UnknownAccount from 'components/UnknownAccount'
-import { GCKB_DECIMAL, GraphQLSchema, client, PCKB_UAN, provider } from 'utils'
+import { GCKB_DECIMAL, GraphQLSchema, client, provider, PCKB_SYMBOL } from 'utils'
 
 export type BasicScript = Record<'args' | 'code_hash' | 'hash_type', string>
 interface AccountBase {
@@ -197,7 +197,7 @@ const AccountOverview: React.FC<AccountOverviewProps> = ({
                     {isBalanceLoading ? (
                       <Skeleton animation="wave" />
                     ) : (
-                      new BigNumber(balance || '0').dividedBy(GCKB_DECIMAL).toFormat() + ` ${PCKB_UAN}`
+                      new BigNumber(balance || '0').dividedBy(GCKB_DECIMAL).toFormat() + ` ${PCKB_SYMBOL}`
                     )}
                   </Typography>
                 }

--- a/components/BridgedRecordList.tsx
+++ b/components/BridgedRecordList.tsx
@@ -18,7 +18,7 @@ import BigNumber from 'bignumber.js'
 
 import Address from 'components/TruncatedAddress'
 import Pagination from 'components/Pagination'
-import { timeDistance, getBridgedRecordListRes, CKB_EXPLORER_URL, CKB_DECIMAL, PCKB_UAN } from 'utils'
+import { timeDistance, getBridgedRecordListRes, CKB_EXPLORER_URL, CKB_DECIMAL, PCKB_UAN, PCKB_SYMBOL } from 'utils'
 
 type ParsedList = ReturnType<typeof getBridgedRecordListRes>
 
@@ -36,7 +36,7 @@ const BridgedRecordList: React.FC<{
               <TableCell component="th">{t('type')}</TableCell>
               <TableCell component="th">{t('value')} </TableCell>
               <TableCell component="th" sx={{ textTransform: 'none' }}>
-                {PCKB_UAN}
+                {PCKB_SYMBOL}
               </TableCell>
               <TableCell component="th">{t('age')} </TableCell>
               {showUser ? <TableCell component="th">{t('account')} </TableCell> : null}

--- a/components/TxList.tsx
+++ b/components/TxList.tsx
@@ -27,7 +27,7 @@ import Address from 'components/TruncatedAddress'
 import PageSize from 'components/PageSize'
 import Pagination from 'components/SimplePagination'
 import TransferDirection from 'components/TransferDirection'
-import { timeDistance, GraphQLSchema, TxStatus, client, GCKB_DECIMAL, useFilterMenu, PCKB_UAN } from 'utils'
+import { timeDistance, GraphQLSchema, TxStatus, client, GCKB_DECIMAL, useFilterMenu, PCKB_SYMBOL } from 'utils'
 
 export type TxListProps = {
   transactions: {
@@ -265,7 +265,7 @@ const TxList: React.FC<TxListProps & { maxCount?: string; pageSize?: number; vie
               </TableCell>
               <TableCell component="th" sx={{ whiteSpace: 'nowrap', textTransform: 'none' }}>{`${t(
                 'value',
-              )} (${PCKB_UAN})`}</TableCell>
+              )} (${PCKB_SYMBOL})`}</TableCell>
               <TableCell component="th">{t('type')}</TableCell>
             </TableRow>
           </TableHead>

--- a/pages/contracts.tsx
+++ b/pages/contracts.tsx
@@ -25,7 +25,7 @@ import SubpageHead from 'components/SubpageHead'
 import Address from 'components/TruncatedAddress'
 import Pagination from 'components/Pagination'
 import PageSize, { SIZES } from 'components/PageSize'
-import { fetchContractList, PCKB_UAN } from 'utils'
+import { fetchContractList, PCKB_SYMBOL } from 'utils'
 
 const ContractList = () => {
   const [t] = useTranslation(['list', 'common'])
@@ -63,7 +63,7 @@ const ContractList = () => {
                     <TableCell component="th">{t(`compiler_version`)}</TableCell>
                     <TableCell component="th">
                       {t(`balance`)}
-                      <span style={{ textTransform: 'none' }}>{`(${PCKB_UAN})`}</span>
+                      <span style={{ textTransform: 'none' }}>{`(${PCKB_SYMBOL})`}</span>
                     </TableCell>
                     <TableCell component="th">{t(`tx_count`)}</TableCell>
                   </TableRow>

--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -59,8 +59,8 @@ import {
   CHANNEL,
   CKB_DECIMAL,
   GCKB_DECIMAL,
+  PCKB_SYMBOL,
   NotFoundException,
-  PCKB_UAN,
 } from 'utils'
 
 type RawTx = Parameters<typeof getTxRes>[0]
@@ -217,7 +217,7 @@ const Tx = (initState: State) => {
         <Typography variant="body2" sx={{ textTransform: 'none' }}>{`${new BigNumber(tx.value || '0')
           .multipliedBy(CKB_DECIMAL)
           .dividedBy(GCKB_DECIMAL)
-          .toFormat()} ${PCKB_UAN}`}</Typography>
+          .toFormat()} ${PCKB_SYMBOL}`}</Typography>
       ),
     },
   ]
@@ -283,7 +283,7 @@ const Tx = (initState: State) => {
           label: 'gasPrice',
           value: (
             <Typography variant="body2" sx={{ textTransform: 'none' }}>
-              {new BigNumber(tx.gasPrice).toFormat() + ` ${PCKB_UAN}`}
+              {new BigNumber(tx.gasPrice).toFormat() + ` ${PCKB_SYMBOL}`}
             </Typography>
           ),
         }
@@ -305,7 +305,7 @@ const Tx = (initState: State) => {
           label: 'fee',
           value: (
             <Typography variant="body2" sx={{ textTransform: 'none' }}>
-              {new BigNumber(tx.gasUsed).times(new BigNumber(tx.gasPrice)).toFormat() + ` ${PCKB_UAN}`}
+              {new BigNumber(tx.gasUsed).times(new BigNumber(tx.gasPrice)).toFormat() + ` ${PCKB_SYMBOL}`}
             </Typography>
           ),
         }

--- a/pages/txs.tsx
+++ b/pages/txs.tsx
@@ -22,7 +22,7 @@ import TxListComp, { fetchTxList } from 'components/TxList'
 import SubpageHead from 'components/SubpageHead'
 import Pagination from 'components/SimplePagination'
 import { SIZES } from 'components/PageSize'
-import { PCKB_UAN } from 'utils'
+import { PCKB_SYMBOL } from 'utils'
 
 const TxList = () => {
   const [t] = useTranslation('list')
@@ -79,7 +79,7 @@ const TxList = () => {
                       </TableCell>
                       <TableCell component="th" sx={{ whiteSpace: 'nowrap', textTransform: 'none' }}>{`${t(
                         'value',
-                      )} (${PCKB_UAN})`}</TableCell>
+                      )} (${PCKB_SYMBOL})`}</TableCell>
                       <TableCell component="th">{t('type')}</TableCell>
                     </TableRow>
                   </TableHead>

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -20,6 +20,7 @@ export const PAGE_SIZE = 20
 export const CKB_DECIMAL = new BigNumber(10 ** 8)
 export const GCKB_DECIMAL = new BigNumber(10 ** 18)
 export const PCKB_UAN = 'pCKB.gw|gb.ckb'
+export const PCKB_SYMBOL = 'pCKB'
 export const SEARCH_FIELDS = 'block hash/txn hash/lockhash/ETH address/token name/token symbol'
 export const MAINNET_HOSTNAME = process.env.NEXT_PUBLIC_MAINNET_EXPLORER_HOSTNAME
 export const TESTNET_HOSTNAME = process.env.NEXT_PUBLIC_TESTNET_EXPLORER_HOSTNAME


### PR DESCRIPTION
pCKB is a special token(default token) so users are all clear
that it's bridged from ckb via force bridge. So in label and
table header it can be simplified as pCKB instead of pCKB.gw|fb.eth

Ref: https://github.com/Magickbase/godwoken_explorer/issues/772

---
1. account detail(balance)
![Pasted Graphic 29](https://user-images.githubusercontent.com/7271329/180423636-f9098a69-7f37-4ff4-9a45-522cc1c36053.png)

2. bridged token list (deposited with pCKB)
![Pasted Graphic 30](https://user-images.githubusercontent.com/7271329/180423729-2b711b33-6ec3-4d29-9b85-d7cf911d4629.png)

3. tx detail(value, price, fee)
![Pasted Graphic 31](https://user-images.githubusercontent.com/7271329/180423782-12bc7a73-1a7d-4842-b9f1-cf18580490f4.png)

4. tx list(value)
![Pasted Graphic 32](https://user-images.githubusercontent.com/7271329/180423891-2381a7bb-e984-4e3c-8dde-9b109fc82c26.png)

5. contract list(balance)
![Pasted Graphic 33](https://user-images.githubusercontent.com/7271329/180423989-3d6584a3-f4e4-4450-b3b5-be35e9a561ad.png)
