### PR TITLE
fix: fix color of text field in contract page

### DIFF
--- a/components/ContractInfo/styles.module.scss
+++ b/components/ContractInfo/styles.module.scss
@@ -42,7 +42,7 @@
       border-radius: 8px;
       font-size: 0.875rem;
       font-weight: 400;
-      color: #999;
+      color: var(--primary-text-color);
       background-color: transparent;
       margin: 0 0 1rem;
     }


### PR DESCRIPTION
color of text field in contract page should be #333 but not #999

Ref: https://github.com/Magickbase/godwoken_explorer/issues/862