### PR TITLE
fix: fix color of links in events of a contract account

### DIFF
--- a/components/ContractEventsList.tsx
+++ b/components/ContractEventsList.tsx
@@ -122,7 +122,7 @@ const ContractEventsList = ({ list }: { list: ParsedEventLog[] }) => {
                         <Link
                           href={`/tx/${item.txHash}`}
                           underline="none"
-                          color="secondary"
+                          color="primary"
                           className="mono-font"
                           sx={{ fontSize: 14 }}
                         >
@@ -134,7 +134,7 @@ const ContractEventsList = ({ list }: { list: ParsedEventLog[] }) => {
                           <Link
                             href={`/block/${item.blockNumber}`}
                             underline="none"
-                            color="secondary"
+                            color="primary"
                             sx={{ fontSize: 14 }}
                           >
                             # {item.blockNumber}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7271329/184927636-4349e030-e322-4b50-be74-a2b0a53b9271.png)

Preview: https://godwoken-explorer-ui-git-fix-color-of-tx-hash-5f09ff-nervosnet.vercel.app/account/0x96c5f1e50c4393efa890699cd9aecf3fb58dcb99?tab=events
Ref: https://github.com/Magickbase/godwoken_explorer/issues/862