### PR TITLE
fix: fix default value of polyjuice status

### DIFF
--- a/utils/api/tx.ts
+++ b/utils/api/tx.ts
@@ -82,7 +82,7 @@ export const getTxRes = (tx: Raw): Parsed => ({
   hash: tx.hash,
   nonce: tx.nonce,
   status: tx.status ?? 'pending',
-  polyjuiceStatus: tx.polyjuice_status ?? 'succeed',
+  polyjuiceStatus: tx.polyjuice_status ?? 'pending',
   timestamp: tx.timestamp ? tx.timestamp * 1000 : -1,
   from: tx.from,
   to: tx.to,


### PR DESCRIPTION
Display 'pending' instead of 'succeed' when polyjuice status is null

Ref: https://github.com/Magickbase/godwoken_explorer/issues/907

Preview:
![image](https://user-images.githubusercontent.com/7271329/190077856-359cb53a-3a72-446d-9d66-71a77ee69a87.png)
