### PR TITLE
feat: token revoke txn loading

### DIFF
--- a/components/TokenApprovalList/RevokeButton.tsx
+++ b/components/TokenApprovalList/RevokeButton.tsx
@@ -30,7 +30,7 @@ type Props = {
   >
   listItem: TokenApprovalEntryType
   account: string
-  hideItem: (txnHash: string) => void
+  hideItem: (item: TokenApprovalEntryType) => void
 }
 
 const mapEthTypeToABI = (item: TokenApprovalEntryType) => {
@@ -113,7 +113,7 @@ const RevokeButton: React.FC<Props> = ({ setAlert, listItem, account, hideItem }
         setAlert({ open: true, type: 'success', msg: t('revoke-success') })
         // seems after the block is created, backend still need a few minutes to update tokenApprovalList,
         // so hide this record right after revoke txn is package in a block
-        hideItem(listItem.transaction_hash)
+        hideItem(listItem)
       }
     },
   })

--- a/components/TokenApprovalList/RevokeButton.tsx
+++ b/components/TokenApprovalList/RevokeButton.tsx
@@ -1,0 +1,184 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'next-i18next'
+import { currentChain, erc1155ABI, GraphQLSchema } from 'utils'
+import { TokenApprovalEntryType } from '.'
+import {
+  ConnectorAlreadyConnectedError,
+  useConnect,
+  erc20ABI,
+  erc721ABI,
+  useContractWrite,
+  usePrepareContractWrite,
+  useWaitForTransaction,
+  ConnectorNotFoundError,
+  useNetwork,
+  useSwitchNetwork,
+  useAccount,
+} from 'wagmi'
+import { CircularProgress } from '@mui/material'
+import DisconnectIcon from 'assets/icons/disconnect.svg'
+import Tooltip from 'components/Tooltip'
+import styles from './styles.module.scss'
+
+type Props = {
+  setAlert: Dispatch<
+    SetStateAction<{
+      open: boolean
+      type?: 'success' | 'error' | 'warning'
+      msg?: string
+    }>
+  >
+  listItem: TokenApprovalEntryType
+  account: string
+  hideItem: (txnHash: string) => void
+}
+
+const mapEthTypeToABI = (item: TokenApprovalEntryType) => {
+  const map = {
+    [GraphQLSchema.TokenType.ERC20]: {
+      address: item.token_contract_address_hash,
+      abi: erc20ABI,
+      function: 'approve',
+      args: [item.spender_address_hash, 0],
+    },
+    [GraphQLSchema.TokenType.ERC721]: {
+      address: item.token_contract_address_hash,
+      abi: erc721ABI,
+      function: 'setApprovalForAll',
+      args: [item.spender_address_hash, false],
+    },
+    [GraphQLSchema.TokenType.ERC1155]: {
+      address: item.token_contract_address_hash,
+      abi: erc1155ABI,
+      function: 'setApprovalForAll',
+      args: [item.spender_address_hash, false],
+    },
+  }
+  return map[item.udt.eth_type]
+}
+
+const RevokeButton: React.FC<Props> = ({ setAlert, listItem, account, hideItem }) => {
+  const [t] = useTranslation(['list', 'tokens', 'account'])
+  const currentContract = mapEthTypeToABI(listItem)
+  const [callWrite, setCallWrite] = useState(false)
+  const [isPackaging, setIsPackaging] = useState(false)
+
+  /* wagmi hooks */
+  const { chain } = useNetwork()
+  const targetChainId = currentChain.id
+  const { switchNetwork } = useSwitchNetwork({
+    onSuccess: () => {
+      setAlert({ open: true, type: 'success', msg: t('switch_network_success') })
+    },
+    onError: () => {
+      setAlert({ open: true, type: 'error', msg: t('user-rejected') })
+    },
+  })
+  const { connect, connectors, isSuccess } = useConnect({
+    chainId: targetChainId,
+    onError(error) {
+      if (error instanceof ConnectorAlreadyConnectedError) {
+        return
+      } else if (error instanceof ConnectorNotFoundError) {
+        setAlert({ open: true, type: 'error', msg: t('ethereum-is-not-injected', { ns: 'tokens' }) })
+      } else {
+        setAlert({ open: true, type: 'error', msg: t('connect-mm-fail') })
+      }
+    },
+  })
+  const connector = connectors[0] // only have metamask for now
+  const { address: connectedAddr, isConnected } = useAccount()
+  const { config, isLoading: isPreparingContract } = usePrepareContractWrite({
+    chainId: targetChainId,
+    addressOrName: currentContract.address,
+    contractInterface: currentContract.abi,
+    functionName: currentContract.function,
+    args: currentContract.args,
+  })
+  const { data: revokeTxn, write } = useContractWrite({
+    ...config,
+    onSuccess: () => {
+      setAlert({ open: true, type: 'success', msg: t('revokeTxn-sent-success') })
+      setIsPackaging(true)
+    },
+    onError: () => {
+      setAlert({ open: true, type: 'error', msg: t('user-rejected') })
+    },
+  })
+  const { isLoading: isRevokeTxnLoading } = useWaitForTransaction({
+    hash: revokeTxn?.hash,
+    onSuccess: data => {
+      if (data?.blockHash) {
+        setIsPackaging(false)
+        setAlert({ open: true, type: 'success', msg: t('revoke-success') })
+        // seems after the block is created, backend still need a few minutes to update tokenApprovalList,
+        // so hide this record right after revoke txn is package in a block
+        hideItem(listItem.transaction_hash)
+      }
+    },
+  })
+
+  const isOwner = connectedAddr ? account.toLowerCase() === connectedAddr.toLowerCase() : true
+  const disabled = !isOwner || isPreparingContract || !connector.ready || isRevokeTxnLoading || isPackaging
+
+  useEffect(() => {
+    if (!isConnected) {
+      connect({ connector, chainId: targetChainId })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (callWrite) {
+      if (chain && chain.id !== targetChainId) {
+        switchNetwork?.(targetChainId)
+      }
+      if (chain && chain?.id === targetChainId) {
+        write?.()
+      }
+    }
+    setCallWrite(false)
+  }, [callWrite, chain, switchNetwork, targetChainId, write])
+
+  const tooltipTitle = useCallback(() => {
+    if (!isOwner || !connector.ready) {
+      return t('not_owner')
+    } else if (isPackaging) {
+      return ''
+    } else {
+      return t('click_to_revoke')
+    }
+  }, [connector.ready, isOwner, isPackaging, t])
+
+  return (
+    <Tooltip title={tooltipTitle()} placement="top">
+      <span>
+        <button
+          className={styles.revoke}
+          disabled={disabled}
+          onClick={() => {
+            if (!isConnected) {
+              connect({ connector, chainId: targetChainId })
+            }
+            setCallWrite(true)
+          }}
+        >
+          {isPackaging ? (
+            <>
+              {t('revoking')}
+              <div className={styles.loading}>
+                <CircularProgress size={12} color="inherit" />
+              </div>
+            </>
+          ) : (
+            <>
+              {t('revoke')} <DisconnectIcon />
+            </>
+          )}
+        </button>
+      </span>
+    </Tooltip>
+  )
+}
+
+export default RevokeButton

--- a/components/TokenApprovalList/index.tsx
+++ b/components/TokenApprovalList/index.tsx
@@ -199,12 +199,15 @@ const TokenApprovalList: React.FC<TokenApprovalListProps & { maxCount?: string; 
 
   // hide and cache:
   // - the listitem has revoke txn packaged successfully in a block but backend not synced yet
-  const hideItem = (txnHash: string) => {
+  const hideItem = (item: TokenApprovalEntryType) => {
+    const newItemHash = item.transaction_hash + item.spender_address_hash
     localStorage.setItem(
       'revokingItems',
-      JSON.stringify([...JSON.parse(localStorage.getItem('revokingItems') ?? '[]'), txnHash]),
+      JSON.stringify([...JSON.parse(localStorage.getItem('revokingItems') ?? '[]'), newItemHash]),
     )
-    setInternalEntries(internalEntries.filter(entry => entry.transaction_hash !== txnHash))
+    setInternalEntries(
+      internalEntries.filter(entry => entry.transaction_hash + entry.spender_address_hash !== newItemHash),
+    )
   }
 
   useEffect(() => {
@@ -213,8 +216,9 @@ const TokenApprovalList: React.FC<TokenApprovalListProps & { maxCount?: string; 
     let newInternalEntries = []
     let newRevokingItems = []
     entries.forEach((item: TokenApprovalEntryType) => {
-      if (oldRevokingItems.includes(item.transaction_hash)) {
-        newRevokingItems.push(item.transaction_hash)
+      const key = item.transaction_hash + item.spender_address_hash
+      if (oldRevokingItems.includes(key)) {
+        newRevokingItems.push(key)
       } else {
         newInternalEntries.push(item)
       }

--- a/components/TokenApprovalList/index.tsx
+++ b/components/TokenApprovalList/index.tsx
@@ -198,15 +198,20 @@ const TokenApprovalList: React.FC<TokenApprovalListProps & { maxCount?: string; 
   }
 
   // hide and cache:
-  // - the listitem has revoke txn packaged successfully in a block but backend not synced yet
+  // - the item has revoke txn packaged successfully in a block but backend not synced yet
   const hideItem = (item: TokenApprovalEntryType) => {
-    const newItemHash = item.transaction_hash + item.spender_address_hash
+    const { transaction_hash, spender_address_hash, token_contract_address_hash, data } = item
+    const newItemKey = transaction_hash + spender_address_hash + token_contract_address_hash + data
     localStorage.setItem(
       'revokingItems',
-      JSON.stringify([...JSON.parse(localStorage.getItem('revokingItems') ?? '[]'), newItemHash]),
+      JSON.stringify([...JSON.parse(localStorage.getItem('revokingItems') ?? '[]'), newItemKey]),
     )
     setInternalEntries(
-      internalEntries.filter(entry => entry.transaction_hash + entry.spender_address_hash !== newItemHash),
+      internalEntries.filter(entry => {
+        const { transaction_hash, spender_address_hash, token_contract_address_hash, data } = entry
+        const entryKey = transaction_hash + spender_address_hash + token_contract_address_hash + data
+        return entryKey !== newItemKey
+      }),
     )
   }
 
@@ -216,7 +221,8 @@ const TokenApprovalList: React.FC<TokenApprovalListProps & { maxCount?: string; 
     let newInternalEntries = []
     let newRevokingItems = []
     entries.forEach((item: TokenApprovalEntryType) => {
-      const key = item.transaction_hash + item.spender_address_hash
+      const { transaction_hash, spender_address_hash, token_contract_address_hash, data } = item
+      const key = transaction_hash + spender_address_hash + token_contract_address_hash + data
       if (oldRevokingItems.includes(key)) {
         newRevokingItems.push(key)
       } else {

--- a/components/TokenApprovalList/styles.module.scss
+++ b/components/TokenApprovalList/styles.module.scss
@@ -30,7 +30,7 @@
 }
 
 .revoke {
-  width: 80px;
+  width: 88px;
   height: 40px;
   background: var(--primary-color);
   border: none;
@@ -47,6 +47,13 @@
     cursor: not-allowed;
     pointer-events: none;
     opacity: 0.6;
+  }
+  .loading {
+    margin-left: 4px;
+    height: 12px;
+    svg {
+      margin-left: 0;
+    }
   }
 }
 

--- a/public/locales/en-US/list.json
+++ b/public/locales/en-US/list.json
@@ -70,10 +70,12 @@
   "approved_type": "Approved Type",
   "approved_spender": "Approved spender",
   "revoke": "Revoke",
+  "revoking": "Revoking",
   "click_to_revoke": "Click to revoke",
   "not_owner": "Only account owner can revoke",
   "connect-mm-fail": "Connect MetaMask failed",
   "revoke-success": "Revoke success",
+  "revokeTxn-sent-success": "Transaction sent success",
   "user-rejected": "User rejected request",
   "please-connect-mm": "Please connect to MetaMask first",
   "switch_network_success": "Switch network success"

--- a/public/locales/zh-CN/list.json
+++ b/public/locales/zh-CN/list.json
@@ -69,10 +69,12 @@
   "approved_type": "许可类型",
   "approved_spender": "许可使用者",
   "revoke": "撤销",
+  "revoking": "撤销中",
   "click_to_revoke": "点击撤销许可",
   "not_owner": "只有账户持有人可以撤销",
   "connect-mm-fail": "连接 MetaMask 失败",
   "revoke-success": "撤销成功",
+  "revokeTxn-sent-success": "交易发送成功",
   "user-rejected": "请求被拒绝",
   "please-connect-mm": "请先连接到 MetaMask",
   "switch_network_success": "切换网络成功"

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { utils, providers } from 'ethers'
-import { NODE_URL, PCKB_UDT_INFO, ZERO_ADDRESS } from './constants'
+import { NODE_URL, PCKB_UDT_INFO, ZERO_ADDRESS, IS_MAINNET } from './constants'
 import { Chain, configureChains, createClient } from 'wagmi'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
@@ -62,6 +62,8 @@ export const testnet: Chain = {
   },
   testnet: true,
 }
+
+export const currentChain = IS_MAINNET ? mainnet : testnet
 
 // wagmi config chains
 const { chains, provider: wagmiProvider } = configureChains(


### PR DESCRIPTION
resolves https://github.com/Magickbase/godwoken_explorer/issues/1027, resolves https://github.com/Magickbase/godwoken_explorer/issues/1011

Gaps after revoke txn is sent out:
txn sent   ------gap1----->   txn being put in a block   ------gap2----->   backend sync and update data

This implementation shows the button's loading state only during gap1, and then hide the revoking item during gap2.  @Keith-CY  @FrederLu 


https://user-images.githubusercontent.com/32790369/193224872-556a4302-51b2-4532-a391-e7e58911f0cf.mov

