### PR TITLE
feat: mark native transfer's method as 'Send'

### DIFF
--- a/components/TxList/index.tsx
+++ b/components/TxList/index.tsx
@@ -193,7 +193,7 @@ const TxList: React.FC<TxListProps & { maxCount?: string; pageSize?: number }> =
                         </div>
                       </Tooltip>
                     ) : (
-                      '-'
+                      <div className={styles.method} data-is-native-transfer="true" />
                     )}
                   </td>
                   <td>

--- a/components/TxList/styles.module.scss
+++ b/components/TxList/styles.module.scss
@@ -22,6 +22,13 @@
 
 .method {
   @include tx-method;
+  &[data-is-native-transfer] {
+    color: var(--secondary-text-color);
+    pointer-events: none;
+    &:after {
+      content: 'Send';
+    }
+  }
 }
 
 .noRecords {

--- a/cypress/integration/block/index.spec.ts
+++ b/cypress/integration/block/index.spec.ts
@@ -206,7 +206,9 @@ context('Block Page', () => {
         })
         .next()
         .should(field => {
-          expect(field.text()).to.eq('-')
+          const badge = field.find('div')
+          expect(badge).to.have.attr('data-is-native-transfer', 'true')
+          expect(window.getComputedStyle(badge[0], 'after').content).to.eq('"Send"')
         })
         .next()
         .should(field => {


### PR DESCRIPTION
This PR marks `Send` as the default `method name` for a `native transfer` transaction

![image](https://user-images.githubusercontent.com/7271329/194836085-216f85a3-7d1a-4bba-89ba-7758b6489bad.png)
Styles after and before update

Ref: https://github.com/Magickbase/godwoken_explorer/issues/999