### PR TITLE
Fix:Tooltip in NFT pages is cropped

### DIFF
--- a/components/NFTActivityList/index.tsx
+++ b/components/NFTActivityList/index.tsx
@@ -5,6 +5,7 @@ import Table from 'components/Table'
 import Address from 'components/TruncatedAddress'
 import Pagination from 'components/SimplePagination'
 import TxStatusIcon from 'components/TxStatusIcon'
+import Tooltip from 'components/Tooltip'
 import TransferDirection from 'components/TransferDirection'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, timeDistance, GraphQLSchema } from 'utils'
@@ -120,14 +121,16 @@ const ActivityList: React.FC<
                 <tr key={item.transaction.eth_hash + item.log_index}>
                   <td>
                     <div className={styles.hash}>
-                      <span className="tooltip" data-tooltip={item.transaction.eth_hash}>
-                        <NextLink href={`/tx/${item.transaction.eth_hash}`}>
-                          <a className="mono-font">{`${item.transaction.eth_hash.slice(
-                            0,
-                            8,
-                          )}...${item.transaction.eth_hash.slice(-8)}`}</a>
-                        </NextLink>
-                      </span>
+                      <Tooltip title={item.transaction.eth_hash} placement="top">
+                        <span>
+                          <NextLink href={`/tx/${item.transaction.eth_hash}`}>
+                            <a className="mono-font">{`${item.transaction.eth_hash.slice(
+                              0,
+                              8,
+                            )}...${item.transaction.eth_hash.slice(-8)}`}</a>
+                          </NextLink>
+                        </span>
+                      </Tooltip>
                       <TxStatusIcon
                         status={item.block.status}
                         isSuccess={item.polyjuice.status === GraphQLSchema.PolyjuiceStatus.Succeed}
@@ -136,13 +139,11 @@ const ActivityList: React.FC<
                   </td>
                   <td>
                     {method ? (
-                      <div
-                        data-tooltip={item.transaction.method_id}
-                        className={`${styles.method} tooltip`}
-                        title={method}
-                      >
-                        {method}
-                      </div>
+                      <Tooltip title={item.transaction.method_id} placement="top">
+                        <div className={styles.method} title={method}>
+                          {method}
+                        </div>
+                      </Tooltip>
                     ) : (
                       '-'
                     )}

--- a/components/SimpleERC20Transferlist/index.tsx
+++ b/components/SimpleERC20Transferlist/index.tsx
@@ -10,6 +10,7 @@ import Pagination from 'components/SimplePagination'
 import TokenLogo from 'components/TokenLogo'
 import FilterMenu from 'components/FilterMenu'
 import RoundedAmount from 'components/RoundedAmount'
+import Tooltip from 'components/Tooltip'
 import SortIcon from 'assets/icons/sort.svg'
 import ChangeIcon from 'assets/icons/change.svg'
 import NoDataIcon from 'assets/icons/no-data.svg'
@@ -171,28 +172,32 @@ const TransferList: React.FC<TransferListProps> = ({ token_transfers: { entries,
               <tr key={`${item.transaction_hash}-${item.log_index}`}>
                 <td>{item.log_index}</td>
                 <td className={styles.address}>
-                  <span className="mono-font tooltip" data-tooltip={item.from_address}>
-                    {item.from_address === ZERO_ADDRESS ? (
-                      'zero address'
-                    ) : (
-                      <HashLink
-                        label={`${item.from_address.slice(0, 8)}...${item.from_address.slice(-8)}`}
-                        href={`/account/${item.from_address}`}
-                      />
-                    )}
-                  </span>
+                  <Tooltip title={item.from_address} placement="top">
+                    <span className="mono-font">
+                      {item.from_address === ZERO_ADDRESS ? (
+                        'zero address'
+                      ) : (
+                        <HashLink
+                          label={`${item.from_address.slice(0, 8)}...${item.from_address.slice(-8)}`}
+                          href={`/account/${item.from_address}`}
+                        />
+                      )}
+                    </span>
+                  </Tooltip>
                 </td>
                 <td className={styles.address}>
-                  <span className="mono-font tooltip" data-tooltip={item.to_address}>
-                    {item.to_address === ZERO_ADDRESS ? (
-                      'zero address'
-                    ) : (
-                      <HashLink
-                        label={`${item.to_address.slice(0, 8)}...${item.to_address.slice(-8)}`}
-                        href={`/account/${item.to_address}`}
-                      />
-                    )}
-                  </span>
+                  <Tooltip title={item.to_address} placement="top">
+                    <span className="mono-font">
+                      {item.to_address === ZERO_ADDRESS ? (
+                        'zero address'
+                      ) : (
+                        <HashLink
+                          label={`${item.to_address.slice(0, 8)}...${item.to_address.slice(-8)}`}
+                          href={`/account/${item.to_address}`}
+                        />
+                      )}
+                    </span>
+                  </Tooltip>
                 </td>
                 <td className={styles.tokenLogo}>
                   <NextLink href={`/token/${item.udt.id}`}>

--- a/pages/token/[id].tsx
+++ b/pages/token/[id].tsx
@@ -185,7 +185,6 @@ const Token: React.FC<Props> = () => {
       ) : (
         '-'
       ),
-      tooltipTitle: token?.supply || '0',
     },
     {
       field: t('holderCount'),


### PR DESCRIPTION
This PR is for fixing the cropped tooltip in NFT pages and the issue of the tooltip in the `method` column.
Before:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/22511289/196757328-faed27a7-f899-473c-bca4-e3b6b5a7cf0a.png">

After:
<img width="1447" alt="image" src="https://user-images.githubusercontent.com/22511289/196757678-55ab2d90-d37c-48fb-899c-f3945b941b72.png">

Ref:https://github.com/Magickbase/godwoken_explorer/issues/1094