### PR TITLE
fix: The L2 Script Hash on the Polyjuice Creator Account page is displayed abnormally.

### DIFF
--- a/components/Polyjuice.tsx
+++ b/components/Polyjuice.tsx
@@ -1,11 +1,12 @@
 import type { PolyjuiceCreator as PolyjuiceCreatorProps } from './AccountOverview'
 import { useTranslation } from 'next-i18next'
 import ScriptCode from 'components/ScriptCode'
-import InfoList from './InfoList'
+import Tooltip from './Tooltip'
+import InfoList, { InfoItermProps } from './InfoList'
 
 const Polyjuice = ({ script, scriptHash }: { script: PolyjuiceCreatorProps['script']; scriptHash: string }) => {
   const [t] = useTranslation('account')
-  const list: Array<{ field: string; content: React.ReactNode; expandable?: boolean }> = [
+  const list: Array<InfoItermProps> = [
     {
       field: t('type'),
       content: `Polyjuice`,
@@ -13,9 +14,9 @@ const Polyjuice = ({ script, scriptHash }: { script: PolyjuiceCreatorProps['scri
     {
       field: t(`l2ScriptHash`),
       content: scriptHash ? (
-        <span className="mono-font tooltip" data-tooltip={scriptHash}>
-          {scriptHash}
-        </span>
+        <Tooltip title={scriptHash} placement="top">
+          <span className="mono-font">{scriptHash}</span>
+        </Tooltip>
       ) : (
         '-'
       ),


### PR DESCRIPTION
Fix the issue when we hover the L2 script hash there is not a tooltip.

Before: 
<img width="971" alt="image" src="https://user-images.githubusercontent.com/22511289/196765757-0dc928cf-2316-4973-a67b-acf9a1da135b.png">

After:
<img width="846" alt="image" src="https://user-images.githubusercontent.com/22511289/196765796-bbf566ba-604b-4f35-9905-df0034cded14.png">


Ref:https://github.com/Magickbase/godwoken_explorer/issues/1084