### PR TITLE
Fix: Read metadata of ERC 721/1155 from backend API

### DIFF
--- a/components/MultiTokenActivityList/index.tsx
+++ b/components/MultiTokenActivityList/index.tsx
@@ -6,10 +6,10 @@ import Address from 'components/TruncatedAddress'
 import Pagination from 'components/SimplePagination'
 import TxStatusIcon from 'components/TxStatusIcon'
 import TransferDirection from 'components/TransferDirection'
+import Tooltip from 'components/Tooltip'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, timeDistance, GraphQLSchema } from 'utils'
 import styles from './styles.module.scss'
-import Tooltip from 'components/Tooltip'
 
 type ActivityListProps = {
   transfers: {

--- a/components/MultiTokenActivityList/index.tsx
+++ b/components/MultiTokenActivityList/index.tsx
@@ -9,6 +9,7 @@ import TransferDirection from 'components/TransferDirection'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, timeDistance, GraphQLSchema } from 'utils'
 import styles from './styles.module.scss'
+import Tooltip from 'components/Tooltip'
 
 type ActivityListProps = {
   transfers: {
@@ -130,14 +131,16 @@ const ActivityList: React.FC<
                 <tr key={item.transaction.eth_hash + item.log_index}>
                   <td>
                     <div className={styles.hash}>
-                      <span className="tooltip" data-tooltip={item.transaction.eth_hash}>
-                        <NextLink href={`/tx/${item.transaction.eth_hash}`}>
-                          <a className="mono-font">{`${item.transaction.eth_hash.slice(
-                            0,
-                            8,
-                          )}...${item.transaction.eth_hash.slice(-8)}`}</a>
-                        </NextLink>
-                      </span>
+                      <Tooltip title={item.transaction.eth_hash} placement="top">
+                        <span>
+                          <NextLink href={`/tx/${item.transaction.eth_hash}`}>
+                            <a className="mono-font">{`${item.transaction.eth_hash.slice(
+                              0,
+                              8,
+                            )}...${item.transaction.eth_hash.slice(-8)}`}</a>
+                          </NextLink>
+                        </span>
+                      </Tooltip>
                       <TxStatusIcon
                         status={item.block.status}
                         isSuccess={item.polyjuice.status === GraphQLSchema.PolyjuiceStatus.Succeed}

--- a/components/MultiTokenInventoryList/index.tsx
+++ b/components/MultiTokenInventoryList/index.tsx
@@ -120,8 +120,8 @@ const MultiTokenInventoryList: React.FC<InventoryListProps> = ({ inventory, view
   return (
     <>
       <div className={styles.container}>
-        {inventory.entries.map(item => (
-          <div key={item.token_id} className={styles.card}>
+        {inventory.entries.map((item, idx) => (
+          <div key={item.token_id + idx} className={styles.card}>
             <NextLink href={`/multi-token-item/${item.contract_address_hash}/${item.token_id}`}>
               <a className={styles.cover}>
                 <img

--- a/pages/multi-token-item/[...id].tsx
+++ b/pages/multi-token-item/[...id].tsx
@@ -54,7 +54,7 @@ interface CollectionInfo
     name: string | null
     symbol: string | null
   }
-  metadata?: MetadataProps
+  metadata: MetadataProps
 }
 interface InfoProps {
   erc1155_udts: {
@@ -75,7 +75,7 @@ interface Variables {
 
 const tabs = ['activity', 'holders', 'inventory', 'metadata']
 
-const fetchInfo = (variables: Variables): Promise<CollectionInfo | undefined> =>
+const fetchInfo = (variables: Variables): Promise<CollectionInfo> =>
   client
     .request<InfoProps>(infoQuery, variables)
     .then(data => ({

--- a/pages/multi-token-item/[...id].tsx
+++ b/pages/multi-token-item/[...id].tsx
@@ -240,7 +240,7 @@ const MultiTokenItem = () => {
               <Skeleton animation="wave" />
             )
           ) : null}
-          {tab === tabs[3] && metadata ? <Metadata {...metadata} /> : null}
+          {tab === tabs[3] && metadata ? <Metadata {...(metadata as MetadataProps)} /> : null}
         </div>
       </div>
     </>


### PR DESCRIPTION
What problem does this PR solve?
------
Each token item of ERC 721/1155 could have its own metadata, as https://v1.testnet.gwscan.com/nft-item/0x784cd3c52813098763c371df8fbe8ed27d2c1ebd/1339?tab=metadata

Now the metadata is fetched from front-end directly so the name and cover of a token item appear slowly.

Issue https://github.com/Magickbase/godwoken_explorer/issues/967 requires a new field metadata to be returned within the API so we can avoid requests in the front-end to deliver info smoothly.

Ref: https://github.com/Magickbase/godwoken_explorer/issues/1108

Check List
------
This PR mainly focuses on replacing the APIs used in the `multi-token-collections`.

### Test
e2e Test
### Task
none


