### PR TITLE
fix: i18n for import token title

### DIFF
--- a/pages/token/[id].tsx
+++ b/pages/token/[id].tsx
@@ -273,11 +273,12 @@ const Token: React.FC<Props> = () => {
                 {t(`tokenInfo`)}
                 {token?.eth_type === 'ERC20' ? (
                   <div className="tooltip" data-tooltip={t('import-token-into-metamask')}>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src="/logos/metamask.png"
                       alt="MetaMask"
                       className={styles.metamask}
-                      title={t('import-into-metamask')}
+                      title={t('import-token-into-metamask')}
                       onClick={handleImportIntoMetamask}
                     />
                   </div>

--- a/pages/token/styles.module.scss
+++ b/pages/token/styles.module.scss
@@ -104,6 +104,11 @@
   align-items: center;
   justify-content: space-between;
   padding-right: 1rem;
+  :global {
+    & .tooltip:hover::before {
+      min-width: 180px !important;
+    }
+  }
 }
 
 .metamask {

--- a/pages/token/styles.module.scss
+++ b/pages/token/styles.module.scss
@@ -106,7 +106,7 @@
   padding-right: 1rem;
   :global {
     & .tooltip:hover::before {
-      min-width: 180px !important;
+      min-width: 180px;
     }
   }
 }


### PR DESCRIPTION
fix https://github.com/Magickbase/godwoken_explorer/issues/1171

Add translation for import token button's title attribute:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/32790369/204704423-f1ce40f6-2169-4e23-9b67-17171a65b07e.png">
