### PR TITLE
fix: tooltip not shown on mobile

### DIFF
--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -2,7 +2,14 @@ import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip'
 import { styled } from '@mui/material/styles'
 
 export default styled(({ className, ...props }: TooltipProps) => (
-  <Tooltip TransitionProps={{ timeout: 200 }} arrow classes={{ popper: className, tooltip: className }} {...props} />
+  <Tooltip
+    TransitionProps={{ timeout: 200 }}
+    arrow
+    classes={{ popper: className, tooltip: className }}
+    enterTouchDelay={0}
+    leaveTouchDelay={3000}
+    {...props}
+  />
 ))(({ theme }) => ({
   [`& .${tooltipClasses.arrow}`]: {
     color: theme.palette.common.black,

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -7,7 +7,7 @@ export default styled(({ className, ...props }: TooltipProps) => (
     arrow
     classes={{ popper: className, tooltip: className }}
     enterTouchDelay={0}
-    leaveTouchDelay={3000}
+    leaveTouchDelay={1000}
     {...props}
   />
 ))(({ theme }) => ({


### PR DESCRIPTION
closes https://github.com/Magickbase/godwoken_explorer/issues/1219

Try to make sure material-ui tooltip shows on mobile:


https://user-images.githubusercontent.com/32790369/208227475-b5c2b6f5-d826-4553-b68a-f953900abb4e.mov

