### PR TITLE
Fix: Update account api for new type declaration

### DIFF
--- a/components/AccountOverview/index.tsx
+++ b/components/AccountOverview/index.tsx
@@ -87,6 +87,40 @@ export type AccountOverviewProps = {
 const accountOverviewQuery = gql`
   query ($script_hash: String, $address: String) {
     account(input: { script_hash: $script_hash, address: $address }) {
+      type
+      eth_address
+      script_hash
+      script
+      transaction_count
+      nonce
+      udt {
+        id
+        name
+        decimal
+        symbol
+        description
+        official_site
+        icon
+      }
+      smart_contract {
+        name
+        deployment_tx_hash
+        compiler_version
+        compiler_file_format
+        contract_source_code
+        constructor_arguments
+        abi
+      }
+      udt {
+        eth_type
+      }
+    }
+  }
+`
+
+const accountOverviewQueryUnion = gql`
+  query ($script_hash: String, $address: String) {
+    account(input: { script_hash: $script_hash, address: $address }) {
       ... on Account {
         type
         eth_address
@@ -142,8 +176,8 @@ const checkSourcify = gql`
 
 type Variables = { address: string } | { script_hash: string }
 
-export const fetchAccountOverview = (variables: Variables) =>
-  client.request<Omit<AccountOverviewProps, 'balance'>>(accountOverviewQuery, variables).then(
+const fetchAccount = (variables: Variables, fetchApi) =>
+  client.request<Omit<AccountOverviewProps, 'balance'>>(fetchApi, variables).then(
     data =>
       data.account ??
       ({
@@ -154,6 +188,8 @@ export const fetchAccountOverview = (variables: Variables) =>
         nonce: 0,
       } as UnknownUser),
   )
+export const fetchAccountOverview = (variables: Variables) => fetchAccount(variables, accountOverviewQuery)
+export const fetchAccountOverviewUnion = (variables: Variables) => fetchAccount(variables, accountOverviewQueryUnion)
 
 export const fetchAccountBalance = (address: string) => provider.getBalance(address).then(res => res.toString())
 

--- a/components/AccountOverview/index.tsx
+++ b/components/AccountOverview/index.tsx
@@ -87,32 +87,34 @@ export type AccountOverviewProps = {
 const accountOverviewQuery = gql`
   query ($script_hash: String, $address: String) {
     account(input: { script_hash: $script_hash, address: $address }) {
-      type
-      eth_address
-      script_hash
-      script
-      transaction_count
-      nonce
-      udt {
-        id
-        name
-        decimal
-        symbol
-        description
-        official_site
-        icon
-      }
-      smart_contract {
-        name
-        deployment_tx_hash
-        compiler_version
-        compiler_file_format
-        contract_source_code
-        constructor_arguments
-        abi
-      }
-      udt {
-        eth_type
+      ... on Account {
+        type
+        eth_address
+        script_hash
+        script
+        transaction_count
+        nonce
+        udt {
+          id
+          name
+          decimal
+          symbol
+          description
+          official_site
+          icon
+        }
+        smart_contract {
+          name
+          deployment_tx_hash
+          compiler_version
+          compiler_file_format
+          contract_source_code
+          constructor_arguments
+          abi
+        }
+        udt {
+          eth_type
+        }
       }
     }
   }

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -84,7 +84,7 @@ const Account = () => {
     enabled: !!id,
   })
   const account = accountOverview ?? accountOverviewUnion
-  const accountOverviewRefetch = () => Promise.all([refetchAccountOverview, refetchAccountOverviewUnion])
+  const accountOverviewRefetch = () => Promise.allSettled([refetchAccountOverview, refetchAccountOverviewUnion])
 
   const deployment_tx_hash = isSmartContractAccount(account) && account?.smart_contract?.deployment_tx_hash
 

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@mui/material'
 import SubpageHead from 'components/SubpageHead'
 import AccountOverview, {
   fetchAccountOverview,
+  fetchAccountOverviewUnion,
   fetchAccountBalance,
   fetchDeployAddress,
   AccountOverviewProps,
@@ -61,19 +62,30 @@ const Account = () => {
     },
   } = useRouter()
   const [t] = useTranslation(['account', 'common'])
-
   const q = isEthAddress(id as string) ? { address: id as string } : { script_hash: id as string }
 
   const pageSize = Number.isNaN(+page_size) ? +SIZES[1] : +page_size
 
   const {
     isLoading: isOverviewLoading,
-    data: account,
+    data: accountOverview,
     refetch: refetchAccountOverview,
   } = useQuery(['account-overview', id], () => fetchAccountOverview(q), {
     refetchInterval: 10000,
     enabled: !!id,
   })
+
+  const {
+    isLoading: isOverviewUnionLoading,
+    data: accountOverviewUnion,
+    refetch: refetchAccountOverviewUnion,
+  } = useQuery(['account-overview-union', id], () => fetchAccountOverviewUnion(q), {
+    refetchInterval: 10000,
+    enabled: !!id,
+  })
+  const account = accountOverview ?? accountOverviewUnion
+  const accountOverviewRefetch = () => Promise.all([refetchAccountOverview, refetchAccountOverviewUnion])
+
   const deployment_tx_hash = isSmartContractAccount(account) && account?.smart_contract?.deployment_tx_hash
 
   const { data: deployerAddr } = useQuery(
@@ -263,12 +275,12 @@ const Account = () => {
           <QRCodeBtn content={id as string} />
         </div>
         <AccountOverview
-          isOverviewLoading={isOverviewLoading}
+          isOverviewLoading={isOverviewLoading || isOverviewUnionLoading}
           isBalanceLoading={isBalanceLoading}
           account={account}
           balance={balance}
           deployerAddr={deployerAddr}
-          refetch={refetchAccountOverview}
+          refetch={accountOverviewRefetch}
         />
         <div className={styles.list}>
           <Tabs


### PR DESCRIPTION
What problem does this PR solve?
------
The account subfield is affected by PR https://github.com/Magickbase/godwoken_explorer/pull/1241, and the graphql query should be updated accordingly.
I updated the request for `account`.

Expect: 
The `Basic Info` will display normally.
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/22511289/210393032-c0bb26aa-7b9b-4e2b-a79a-f683491fbd03.png">

Ref: 
https://github.com/Magickbase/godwoken_explorer/pull/1241
https://github.com/Magickbase/godwoken_explorer/issues/1246

Check List
------



### Test
e2e Test
### Task
none
