### PR TITLE
Fix: Loading of account overview is displayed periodically

### DIFF
--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -275,8 +275,8 @@ const Account = () => {
           <QRCodeBtn content={id as string} />
         </div>
         <AccountOverview
-          isOverviewLoading={isOverviewLoading || isOverviewUnionLoading}
-          isBalanceLoading={isBalanceLoading}
+          isOverviewLoading={!account && (isOverviewLoading || isOverviewUnionLoading)}
+          isBalanceLoading={!account && isBalanceLoading}
           account={account}
           balance={balance}
           deployerAddr={deployerAddr}


### PR DESCRIPTION
What problem does this PR solve?
------
Only the loading on mount is necessary, and values could be updated seamlessly without a loading on refreshing

Expect: 
The `Basic Info` and `Overview`will be updated without a loading.
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/22511289/210749123-c891af16-2263-4dd5-bf84-23a387d348f8.png">


Ref: 
https://github.com/Magickbase/godwoken_explorer/issues/1255

Check List
------



### Test
e2e Test
### Task
none
