### PR TITLE
Fix:update .bit name in nft-collection and bridge token

### DIFF
--- a/components/AddressWithDomain/index.tsx
+++ b/components/AddressWithDomain/index.tsx
@@ -13,18 +13,22 @@ type Props = {
 
 const AddressWithDomain = ({ domain, hash, href = '', leading = 8 }: Props) => {
   return (
-    <div className={styles.container}>
-      <Tooltip title=".bit Name" placement="top">
-        <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
-      </Tooltip>
-      <Tooltip title={hash} placement="top">
-        <div>
-          <HashLink
-            label={domain?.length > leading * 2 ? `${domain?.slice(0, leading)}...${domain?.slice(-leading)}` : domain}
-            href={href}
-          />
-        </div>
-      </Tooltip>
+    <div>
+      <div className={styles.container}>
+        <Tooltip title=".bit Name" placement="top">
+          <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
+        </Tooltip>
+        <Tooltip title={hash} placement="top">
+          <div>
+            <HashLink
+              label={
+                domain?.length > leading * 2 ? `${domain?.slice(0, leading)}...${domain?.slice(-leading)}` : domain
+              }
+              href={href}
+            />
+          </div>
+        </Tooltip>
+      </div>
     </div>
   )
 }

--- a/components/AddressWithDomain/index.tsx
+++ b/components/AddressWithDomain/index.tsx
@@ -14,22 +14,18 @@ type Props = {
 
 const AddressWithDomain = ({ domain, hash, href = '', leading = 8, placement = 'top' }: Props) => {
   return (
-    <div>
-      <div className={styles.container}>
-        <Tooltip title=".bit Name" placement={placement}>
-          <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
-        </Tooltip>
-        <Tooltip title={hash} placement={placement}>
-          <div>
-            <HashLink
-              label={
-                domain?.length > leading * 2 ? `${domain?.slice(0, leading)}...${domain?.slice(-leading)}` : domain
-              }
-              href={href}
-            />
-          </div>
-        </Tooltip>
-      </div>
+    <div className={styles.container}>
+      <Tooltip title=".bit Name" placement={placement}>
+        <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
+      </Tooltip>
+      <Tooltip title={hash} placement={placement}>
+        <div>
+          <HashLink
+            label={domain?.length > leading * 2 ? `${domain?.slice(0, leading)}...${domain?.slice(-leading)}` : domain}
+            href={href}
+          />
+        </div>
+      </Tooltip>
     </div>
   )
 }

--- a/components/AddressWithDomain/index.tsx
+++ b/components/AddressWithDomain/index.tsx
@@ -9,16 +9,17 @@ type Props = {
   hash: string
   href: string
   leading?: number
+  placement?: 'top' | 'bottom'
 }
 
-const AddressWithDomain = ({ domain, hash, href = '', leading = 8 }: Props) => {
+const AddressWithDomain = ({ domain, hash, href = '', leading = 8, placement = 'top' }: Props) => {
   return (
     <div>
       <div className={styles.container}>
-        <Tooltip title=".bit Name" placement="top">
+        <Tooltip title=".bit Name" placement={placement}>
           <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
         </Tooltip>
-        <Tooltip title={hash} placement="top">
+        <Tooltip title={hash} placement={placement}>
           <div>
             <HashLink
               label={

--- a/components/AddressWithDomain/index.tsx
+++ b/components/AddressWithDomain/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 const AddressWithDomain = ({ domain, hash, href = '', leading = 8 }: Props) => {
   return (
     <div className={styles.container}>
-      <Tooltip title={domain} placement="top">
+      <Tooltip title=".bit Name" placement="top">
         <img src={`${IMG_URL}bit-logo.svg`} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
       </Tooltip>
       <Tooltip title={hash} placement="top">

--- a/components/AddressWithDomain/styles.module.scss
+++ b/components/AddressWithDomain/styles.module.scss
@@ -3,8 +3,8 @@
   align-items: center;
   text-transform: initial;
   & img {
-    width: 16px;
-    height: 16px;
+    width: 16px !important;
+    height: 16px !important;
     border-radius: 50%;
     margin-right: 2px;
   }

--- a/components/MultiTokenActivityList/index.tsx
+++ b/components/MultiTokenActivityList/index.tsx
@@ -125,8 +125,8 @@ const ActivityList: React.FC<
           {transfers?.metadata.total_count ? (
             transfers.entries.map(item => {
               const method = item.transaction.method_name || item.transaction.method_id
-              const from_bit_alias = item?.from_account?.bit_alias
-              const to_bit_alias = item?.to_account?.bit_alias
+              const from_bit_alias = item.from_account.bit_alias
+              const to_bit_alias = item.to_account.bit_alias
 
               const token_ids = Array.isArray(item.token_ids) ? item.token_ids : [item.token_id]
               const amounts = Array.isArray(item.amounts) ? item.amounts : [item.amount]
@@ -170,10 +170,10 @@ const ActivityList: React.FC<
                     </time>
                   </td>
                   <td>
-                    <Address address={item.from_address} type={item.from_account?.type} domain={from_bit_alias} />
+                    <Address address={item.from_address} type={item.from_account.type} domain={from_bit_alias} />
                   </td>
                   <td>
-                    <Address address={item.to_address} type={item.to_account?.type} domain={to_bit_alias} />
+                    <Address address={item.to_address} type={item.to_account.type} domain={to_bit_alias} />
                   </td>
                   {viewer ? (
                     <td>

--- a/components/MultiTokenActivityList/index.tsx
+++ b/components/MultiTokenActivityList/index.tsx
@@ -125,8 +125,8 @@ const ActivityList: React.FC<
           {transfers?.metadata.total_count ? (
             transfers.entries.map(item => {
               const method = item.transaction.method_name || item.transaction.method_id
-              const from_bit_alias = item.from_account.bit_alias
-              const to_bit_alias = item.to_account.bit_alias
+              const fromBitAlias = item.from_account.bit_alias
+              const toBitAlias = item.to_account.bit_alias
 
               const token_ids = Array.isArray(item.token_ids) ? item.token_ids : [item.token_id]
               const amounts = Array.isArray(item.amounts) ? item.amounts : [item.amount]
@@ -170,10 +170,10 @@ const ActivityList: React.FC<
                     </time>
                   </td>
                   <td>
-                    <Address address={item.from_address} type={item.from_account.type} domain={from_bit_alias} />
+                    <Address address={item.from_address} type={item.from_account.type} domain={fromBitAlias} />
                   </td>
                   <td>
-                    <Address address={item.to_address} type={item.to_account.type} domain={to_bit_alias} />
+                    <Address address={item.to_address} type={item.to_account.type} domain={toBitAlias} />
                   </td>
                   {viewer ? (
                     <td>

--- a/components/MultiTokenHolderList/index.tsx
+++ b/components/MultiTokenHolderList/index.tsx
@@ -117,9 +117,6 @@ const MultiTokenHolderList: React.FC<HolderListProps> = ({ holders }) => {
               const address = item.account?.eth_address
               const domain = item.account?.bit_alias
 
-              console.log(address, 'address')
-              console.log(domain, 'domain')
-
               return (
                 <tr key={address}>
                   <td>{item.rank}</td>

--- a/components/MultiTokenHolderList/index.tsx
+++ b/components/MultiTokenHolderList/index.tsx
@@ -4,6 +4,8 @@ import Table from 'components/Table'
 import Address from 'components/TruncatedAddress'
 import Pagination from 'components/SimplePagination'
 import NoDataIcon from 'assets/icons/no-data.svg'
+import { useTheme } from '@mui/material/styles'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { client, GraphQLSchema } from 'utils'
 
 import styles from './styles.module.scss'
@@ -57,6 +59,10 @@ const itemHolderListQuery = gql`
         rank
         address_hash
         quantity
+        account {
+          bit_alias
+          eth_address
+        }
       }
       metadata {
         before
@@ -92,6 +98,8 @@ export const fetchItemHoldersList = (variables: ItemHoldersVariables): Promise<H
 
 const MultiTokenHolderList: React.FC<HolderListProps> = ({ holders }) => {
   const [t] = useTranslation('list')
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
     <>
@@ -109,12 +117,14 @@ const MultiTokenHolderList: React.FC<HolderListProps> = ({ holders }) => {
               const address = item.account?.eth_address
               const domain = item.account?.bit_alias
 
+              console.log(address, 'address')
+              console.log(domain, 'domain')
+
               return (
                 <tr key={address}>
                   <td>{item.rank}</td>
                   <td className={styles.address}>
-                    <Address address={address} domain={domain} />
-                    <Address address={address} domain={domain} leading={22} />
+                    <Address address={address} domain={domain} leading={!isMobile ? 22 : 8} />
                   </td>
                   <td>{(+item.quantity).toLocaleString('en')}</td>
                 </tr>

--- a/components/MultiTokenHolderList/index.tsx
+++ b/components/MultiTokenHolderList/index.tsx
@@ -5,6 +5,7 @@ import Address from 'components/TruncatedAddress'
 import Pagination from 'components/SimplePagination'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, GraphQLSchema } from 'utils'
+
 import styles from './styles.module.scss'
 
 export type HolderListProps = {
@@ -13,6 +14,7 @@ export type HolderListProps = {
       rank: number
       address_hash: string
       quantity: number
+      account: Pick<GraphQLSchema.Account, 'bit_alias' | 'eth_address'>
     }>
     metadata: GraphQLSchema.PageMetadata
   }
@@ -24,6 +26,10 @@ const holderFragment = gql`
       rank
       address_hash
       quantity
+      account {
+        bit_alias
+        eth_address
+      }
     }
     metadata {
       before
@@ -99,16 +105,21 @@ const MultiTokenHolderList: React.FC<HolderListProps> = ({ holders }) => {
         </thead>
         <tbody>
           {holders?.metadata.total_count ? (
-            holders.entries.map(item => (
-              <tr key={item.address_hash}>
-                <td>{item.rank}</td>
-                <td className={styles.address}>
-                  <Address address={item.address_hash} />
-                  <Address address={item.address_hash} leading={22} />
-                </td>
-                <td>{(+item.quantity).toLocaleString('en')}</td>
-              </tr>
-            ))
+            holders.entries.map(item => {
+              const address = item.account?.eth_address
+              const domain = item.account?.bit_alias
+
+              return (
+                <tr key={address}>
+                  <td>{item.rank}</td>
+                  <td className={styles.address}>
+                    <Address address={address} domain={domain} />
+                    <Address address={address} domain={domain} leading={22} />
+                  </td>
+                  <td>{(+item.quantity).toLocaleString('en')}</td>
+                </tr>
+              )
+            })
           ) : (
             <tr>
               <td colSpan={3}>

--- a/components/MultiTokenHolderList/styles.module.scss
+++ b/components/MultiTokenHolderList/styles.module.scss
@@ -1,17 +1,20 @@
 @import '../../styles/mixin.scss';
-.address {
-  div:first-of-type {
-    display: none;
-  }
-  @media screen and (max-width: 1024px) {
-    div:first-of-type {
-      display: block;
-    }
-    div:last-of-type {
-      display: none;
-    }
-  }
-}
+// .address {
+//   div:first-of-type {
+//     display: none;
+//   }
+//   div:last-of-type {
+//     display: flex;
+//   }
+//   @media screen and (max-width: 1024px) {
+//     div:first-of-type {
+//       display: flex;
+//     }
+//     div:last-of-type {
+//       display: none;
+//     }
+//   }
+// }
 
 .noRecords {
   @include empty-list;

--- a/components/MultiTokenHolderList/styles.module.scss
+++ b/components/MultiTokenHolderList/styles.module.scss
@@ -1,20 +1,4 @@
 @import '../../styles/mixin.scss';
-// .address {
-//   div:first-of-type {
-//     display: none;
-//   }
-//   div:last-of-type {
-//     display: flex;
-//   }
-//   @media screen and (max-width: 1024px) {
-//     div:first-of-type {
-//       display: flex;
-//     }
-//     div:last-of-type {
-//       display: none;
-//     }
-//   }
-// }
 
 .noRecords {
   @include empty-list;

--- a/components/MultiTokenInventoryList/index.tsx
+++ b/components/MultiTokenInventoryList/index.tsx
@@ -15,7 +15,9 @@ type InventoryListProps = {
       token_id: string
       contract_address_hash: string
       counts: string
-      owner?: Record<string, any>
+      owner?: {
+        account: Pick<GraphQLSchema.Account, 'bit_alias' | 'eth_address'>
+      }
       udt?: {
         id: number
         name: string | null
@@ -157,7 +159,6 @@ const MultiTokenInventoryList: React.FC<InventoryListProps> = ({ inventory, view
                 <div className={styles.info}>
                   <span>{t('owner')}</span>
                   <Address address={eth_address} domain={bit_alias} />
-                  {/* <HashLink href={`/account/${item.owner}`} label={item.owner} /> */}
                 </div>
               ) : (
                 <div className={styles.info}>

--- a/components/MultiTokenInventoryList/index.tsx
+++ b/components/MultiTokenInventoryList/index.tsx
@@ -4,6 +4,7 @@ import { gql } from 'graphql-request'
 import Pagination from 'components/SimplePagination'
 import HashLink from 'components/HashLink'
 import Tooltip from 'components/Tooltip'
+import Address from 'components/TruncatedAddress'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, getIpfsUrl, GraphQLSchema, handleNftImageLoadError } from 'utils'
 import styles from './styles.module.scss'
@@ -14,7 +15,7 @@ type InventoryListProps = {
       token_id: string
       contract_address_hash: string
       counts: string
-      owner?: string
+      owner?: Record<string, any>
       udt?: {
         id: number
         name: string | null
@@ -120,51 +121,58 @@ const MultiTokenInventoryList: React.FC<InventoryListProps> = ({ inventory, view
   return (
     <>
       <div className={styles.container}>
-        {inventory.entries.map((item, idx) => (
-          <div key={item.token_id + idx} className={styles.card}>
-            <NextLink href={`/multi-token-item/${item.contract_address_hash}/${item.token_id}`}>
-              <a className={styles.cover}>
-                <img
-                  src={getIpfsUrl(item.token_instance?.metadata?.image) ?? '/images/nft-placeholder.svg'}
-                  onError={handleNftImageLoadError}
-                  alt="nft-cover"
-                  loading="lazy"
-                />
-              </a>
-            </NextLink>
+        {inventory.entries.map((item, idx) => {
+          const {
+            owner: {
+              account: { bit_alias, eth_address },
+            },
+          } = item
 
-            {viewer ? (
-              <div className={styles.info}>
-                <span>{t('name')}</span>
-                <span>{item.udt.name?.length > 15 ? item.udt.name.slice(0, 15) + '...' : item.udt.name || '-'}</span>
-              </div>
-            ) : (
-              <div className={styles.info}>
-                <span>{t('quantity')}</span>
-                <span>{(+item.counts || 0).toLocaleString('en')}</span>
-              </div>
-            )}
+          return (
+            <div key={item.token_id + idx} className={styles.card}>
+              <NextLink href={`/multi-token-item/${item.contract_address_hash}/${item.token_id}`}>
+                <a className={styles.cover}>
+                  <img
+                    src={getIpfsUrl(item.token_instance?.metadata?.image) ?? '/images/nft-placeholder.svg'}
+                    onError={handleNftImageLoadError}
+                    alt="nft-cover"
+                    loading="lazy"
+                  />
+                </a>
+              </NextLink>
 
-            {token_id ? (
-              <Tooltip title={item.owner} placement="bottom">
+              {viewer ? (
+                <div className={styles.info}>
+                  <span>{t('name')}</span>
+                  <span>{item.udt.name?.length > 15 ? item.udt.name.slice(0, 15) + '...' : item.udt.name || '-'}</span>
+                </div>
+              ) : (
+                <div className={styles.info}>
+                  <span>{t('quantity')}</span>
+                  <span>{(+item.counts || 0).toLocaleString('en')}</span>
+                </div>
+              )}
+
+              {token_id ? (
                 <div className={styles.info}>
                   <span>{t('owner')}</span>
-                  <HashLink href={`/account/${item.owner}`} label={item.owner} />
+                  <Address address={eth_address} domain={bit_alias} />
+                  {/* <HashLink href={`/account/${item.owner}`} label={item.owner} /> */}
                 </div>
-              </Tooltip>
-            ) : (
-              <div className={styles.info}>
-                <span>{t('token-id')}</span>
-                <HashLink
-                  label={item.token_id}
-                  href={`/multi-token-item/${item.contract_address_hash}/${item.token_id}`}
-                  monoFont={false}
-                  style={{ fontSize: 14 }}
-                />
-              </div>
-            )}
-          </div>
-        ))}
+              ) : (
+                <div className={styles.info}>
+                  <span>{t('token-id')}</span>
+                  <HashLink
+                    label={item.token_id}
+                    href={`/multi-token-item/${item.contract_address_hash}/${item.token_id}`}
+                    monoFont={false}
+                    style={{ fontSize: 14 }}
+                  />
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {inventory.metadata.total_count ? <Pagination {...inventory.metadata} /> : null}

--- a/components/NFTActivityList/index.tsx
+++ b/components/NFTActivityList/index.tsx
@@ -118,8 +118,8 @@ const ActivityList: React.FC<
           {transfers?.metadata.total_count ? (
             transfers.entries.map(item => {
               const method = item.transaction.method_name || item.transaction.method_id
-              const from_bit_alias = item?.from_account?.bit_alias
-              const to_bit_alias = item?.to_account?.bit_alias
+              const from_bit_alias = item.from_account.bit_alias
+              const to_bit_alias = item.to_account.bit_alias
 
               return (
                 <tr key={item.transaction.eth_hash + item.log_index}>
@@ -158,10 +158,10 @@ const ActivityList: React.FC<
                     </time>
                   </td>
                   <td>
-                    <Address address={item.from_address} type={item.from_account?.type} domain={from_bit_alias} />
+                    <Address address={item.from_address} type={item.from_account.type} domain={from_bit_alias} />
                   </td>
                   <td>
-                    <Address address={item.to_address} type={item.to_account?.type} domain={to_bit_alias} />
+                    <Address address={item.to_address} type={item.to_account.type} domain={to_bit_alias} />
                   </td>
                   {viewer ? (
                     <td>

--- a/components/NFTActivityList/index.tsx
+++ b/components/NFTActivityList/index.tsx
@@ -118,8 +118,8 @@ const ActivityList: React.FC<
           {transfers?.metadata.total_count ? (
             transfers.entries.map(item => {
               const method = item.transaction.method_name || item.transaction.method_id
-              const from_bit_alias = item.from_account.bit_alias
-              const to_bit_alias = item.to_account.bit_alias
+              const fromBitAlias = item.from_account.bit_alias
+              const toBitAlias = item.to_account.bit_alias
 
               return (
                 <tr key={item.transaction.eth_hash + item.log_index}>
@@ -158,10 +158,10 @@ const ActivityList: React.FC<
                     </time>
                   </td>
                   <td>
-                    <Address address={item.from_address} type={item.from_account.type} domain={from_bit_alias} />
+                    <Address address={item.from_address} type={item.from_account.type} domain={fromBitAlias} />
                   </td>
                   <td>
-                    <Address address={item.to_address} type={item.to_account.type} domain={to_bit_alias} />
+                    <Address address={item.to_address} type={item.to_account.type} domain={toBitAlias} />
                   </td>
                   {viewer ? (
                     <td>

--- a/components/NFTHolderList/index.tsx
+++ b/components/NFTHolderList/index.tsx
@@ -13,6 +13,9 @@ export type HolderListProps = {
       rank: number
       address_hash: string
       quantity: string
+      account: {
+        bit_alias: string
+      }
     }>
     metadata: GraphQLSchema.PageMetadata
   }
@@ -25,6 +28,9 @@ const holdersListQuery = gql`
         rank
         address_hash
         quantity
+        account {
+          bit_alias
+        }
       }
       metadata {
         before
@@ -65,8 +71,8 @@ const NFTHolderList: React.FC<HolderListProps> = ({ holders }) => {
               <tr key={item.address_hash}>
                 <td>{item.rank}</td>
                 <td className={styles.address}>
-                  <Address address={item.address_hash} />
-                  <Address address={item.address_hash} leading={22} />
+                  <Address address={item.address_hash} domain={item.account?.bit_alias} />
+                  <Address address={item.address_hash} domain={item.account?.bit_alias} leading={22} />
                 </td>
                 <td>{(+item.quantity).toLocaleString('en')}</td>
               </tr>

--- a/components/NFTHolderList/index.tsx
+++ b/components/NFTHolderList/index.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'next-i18next'
 import { gql } from 'graphql-request'
+import { useTheme } from '@mui/material/styles'
 import Table from 'components/Table'
 import Address from 'components/TruncatedAddress'
 import Pagination from 'components/SimplePagination'
 import NoDataIcon from 'assets/icons/no-data.svg'
 import { client, GraphQLSchema } from 'utils'
 import styles from './styles.module.scss'
+import useMediaQuery from '@mui/material/useMediaQuery'
 
 export type HolderListProps = {
   holders: {
@@ -54,6 +56,8 @@ export const fetchHoldersList = (variables: {
 
 const NFTHolderList: React.FC<HolderListProps> = ({ holders }) => {
   const [t] = useTranslation('list')
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
     <>
@@ -70,9 +74,12 @@ const NFTHolderList: React.FC<HolderListProps> = ({ holders }) => {
             holders.entries.map(item => (
               <tr key={item.address_hash}>
                 <td>{item.rank}</td>
-                <td className={styles.address}>
-                  <Address address={item.address_hash} domain={item.account?.bit_alias} />
-                  <Address address={item.address_hash} domain={item.account?.bit_alias} leading={22} />
+                <td>
+                  {isMobile ? (
+                    <Address address={item.address_hash} domain={item.account?.bit_alias} />
+                  ) : (
+                    <Address address={item.address_hash} domain={item.account?.bit_alias} leading={22} />
+                  )}
                 </td>
                 <td>{(+item.quantity).toLocaleString('en')}</td>
               </tr>
@@ -87,6 +94,14 @@ const NFTHolderList: React.FC<HolderListProps> = ({ holders }) => {
               </td>
             </tr>
           )}
+
+          {/* <div className={styles.test}>
+            <div>
+              first floor
+              <div>first -1 floor</div>
+            </div>
+            <div>second</div>
+          </div> */}
         </tbody>
       </Table>
       {!holders?.metadata.total_count ? null : (

--- a/components/NFTHolderList/index.tsx
+++ b/components/NFTHolderList/index.tsx
@@ -94,14 +94,6 @@ const NFTHolderList: React.FC<HolderListProps> = ({ holders }) => {
               </td>
             </tr>
           )}
-
-          {/* <div className={styles.test}>
-            <div>
-              first floor
-              <div>first -1 floor</div>
-            </div>
-            <div>second</div>
-          </div> */}
         </tbody>
       </Table>
       {!holders?.metadata.total_count ? null : (

--- a/components/NFTHolderList/styles.module.scss
+++ b/components/NFTHolderList/styles.module.scss
@@ -1,17 +1,4 @@
 @import '../../styles/mixin.scss';
-.address {
-  div:first-of-type {
-    display: none;
-  }
-  @media screen and (max-width: 1024px) {
-    div:first-of-type {
-      display: block;
-    }
-    div:last-of-type {
-      display: none;
-    }
-  }
-}
 
 .noRecords {
   @include empty-list;

--- a/components/NFTInventoryList/styles.module.scss
+++ b/components/NFTInventoryList/styles.module.scss
@@ -45,7 +45,12 @@
   }
   .info {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+
+    @media screen and (max-width: 1024px) {
+      justify-content: space-between;
+    }
+
     span:nth-child(1) {
       flex-basis: 80px;
       flex-shrink: 0;

--- a/components/TitleWithDomain/index.tsx
+++ b/components/TitleWithDomain/index.tsx
@@ -1,6 +1,6 @@
+import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
-import Link from 'next/link'
-import { DOMAIN_LOGO_BASE_URL } from 'utils/constants'
+import { BIT_DATA_BASE_URL, BIT_LOGO_BASE_URL } from 'utils/constants'
 
 import styles from './styles.module.scss'
 
@@ -8,23 +8,23 @@ type Props = {
   domain: string
 }
 
-const BIT_PAGE = 'https://data.did.id'
-
 const TitleWithDomain = ({ domain = '' }: Props) => {
   const [t] = useTranslation('account')
-  const logoUrl = DOMAIN_LOGO_BASE_URL + domain
+  const logoUrl = BIT_LOGO_BASE_URL + domain
+  const bitUrl = BIT_DATA_BASE_URL + domain
 
   return (
     <div className={styles.title}>
       <span>{t(`basicInfo`)}</span>
-      <div className={`${styles['logo-domain']} tooltip`} data-tooltip={domain}>
-        <img src={logoUrl} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
-        <Link href={`${BIT_PAGE}/${domain}`}>
-          <a className={styles.domain} target="_blank" rel="noopener noreferrer">
-            {domain}
-          </a>
-        </Link>
-      </div>
+
+      <NextLink href={bitUrl}>
+        <a target="_blank" rel="noopener noreferrer">
+          <div className={`${styles['logo-domain']} tooltip`} data-tooltip={domain}>
+            <img src={logoUrl} loading="lazy" crossOrigin="anonymous" referrerPolicy="no-referrer" />
+            <div className={styles.domian}>{domain}</div>
+          </div>
+        </a>
+      </NextLink>
     </div>
   )
 }

--- a/components/TitleWithDomain/styles.module.scss
+++ b/components/TitleWithDomain/styles.module.scss
@@ -4,6 +4,10 @@
   align-items: center;
   padding-right: 16px;
 
+  a {
+    color: #333333;
+  }
+
   @media screen and (max-width: 1024px) {
     padding-right: unset;
   }

--- a/components/TruncatedAddress.tsx
+++ b/components/TruncatedAddress.tsx
@@ -12,6 +12,7 @@ const TruncatedAddress = ({
   type,
   monoFont = true,
   domain,
+  placement = 'top',
 }: {
   address: string
   leading?: number
@@ -20,10 +21,11 @@ const TruncatedAddress = ({
   type?: GraphQLSchema.AccountType
   monoFont?: boolean
   domain?: string
+  placement?: 'top' | 'bottom'
 }) => {
   if (address === ZERO_ADDRESS) {
     return (
-      <Tooltip title={address} placement="top" sx={sx}>
+      <Tooltip title={address} placement={placement} sx={sx}>
         <Box sx={sx}>
           <span className="mono-font" style={{ color: 'var(--primary-text-color)', userSelect: 'none' }}>
             zero address
@@ -54,10 +56,16 @@ const TruncatedAddress = ({
     <>
       {domain ? (
         <Box sx={sx}>
-          <AddressWithDomain domain={domain} hash={address} href={`/account/${address}`} leading={leading} />
+          <AddressWithDomain
+            domain={domain}
+            hash={address}
+            href={`/account/${address}`}
+            leading={leading}
+            placement={placement}
+          />
         </Box>
       ) : (
-        <Tooltip title={address} placement="top" sx={sx}>
+        <Tooltip title={address} placement={placement} sx={sx}>
           <Box sx={sx}>
             <HashLink label={label} href={`/account/${address}`} monoFont={monoFont} />
           </Box>

--- a/components/TxList/index.tsx
+++ b/components/TxList/index.tsx
@@ -29,7 +29,10 @@ export type TxListProps = {
       block?: Pick<GraphQLSchema.Block, 'hash' | 'number' | 'status' | 'timestamp'>
       from_account: Pick<GraphQLSchema.Account, 'eth_address' | 'script_hash' | 'type' | 'bit_alias'>
       to_account: Pick<GraphQLSchema.Account, 'eth_address' | 'script_hash' | 'type' | 'bit_alias'>
-      polyjuice: Pick<GraphQLSchema.Polyjuice, 'value' | 'status' | 'native_transfer_address_hash'>
+      polyjuice: Pick<
+        GraphQLSchema.Polyjuice,
+        'value' | 'status' | 'native_transfer_address_hash' | 'native_transfer_account'
+      >
     }>
     metadata: GraphQLSchema.PageMetadata
   }
@@ -101,6 +104,9 @@ const txListQuery = gql`
           value
           status
           native_transfer_address_hash
+          native_transfer_account {
+            bit_alias
+          }
         }
         type
       }
@@ -220,6 +226,7 @@ const TxList: React.FC<TxListProps & { maxCount?: string; pageSize?: number }> =
               if (item.polyjuice?.native_transfer_address_hash) {
                 to = item.polyjuice.native_transfer_address_hash
                 toType = GraphQLSchema.AccountType.EthUser
+                to_alias = item.polyjuice.native_transfer_account.bit_alias
               }
 
               const method = item.method_name || item.method_id

--- a/components/TxList/index.tsx
+++ b/components/TxList/index.tsx
@@ -223,8 +223,8 @@ const TxList: React.FC<TxListProps & { maxCount?: string; pageSize?: number }> =
               let toType = item.to_account?.type
               let to_alias = item.to_account?.bit_alias
 
-              if (item.polyjuice?.native_transfer_address_hash) {
-                to = item.polyjuice.native_transfer_address_hash
+              if (item.polyjuice?.native_transfer_account) {
+                to = item.polyjuice.native_transfer_account.eth_address
                 toType = GraphQLSchema.AccountType.EthUser
                 to_alias = item.polyjuice.native_transfer_account.bit_alias
               }

--- a/components/TxList/index.tsx
+++ b/components/TxList/index.tsx
@@ -106,6 +106,7 @@ const txListQuery = gql`
           native_transfer_address_hash
           native_transfer_account {
             bit_alias
+            eth_address
           }
         }
         type

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nervosnetwork/ckb-sdk-utils": "0.103.1",
         "bignumber.js": "9.1.1",
         "dayjs": "1.11.7",
+        "dotbit": "0.4.14",
         "ethers": "5.7.2",
         "graphql": "16.6.0",
         "graphql-request": "5.1.0",
@@ -2989,6 +2990,24 @@
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==",
       "license": "MIT"
     },
+    "node_modules/@ensdomains/address-encoder": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@ensdomains/address-encoder/-/address-encoder-0.2.20.tgz",
+      "integrity": "sha512-itaFxXavhdEnDcB2MuESzF9DDFb4xTNm5GyJu+MqzyplOKr6KtQBnj2LtH95qXpFxFhXQHoArOlGb/dfhkwfAg==",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "blakejs": "^1.1.0",
+        "bn.js": "^4.11.8",
+        "bs58": "^4.0.1",
+        "crypto-addr-codec": "^0.1.7",
+        "js-crc": "^0.2.0",
+        "js-sha256": "^0.9.0",
+        "js-sha512": "^0.8.0",
+        "nano-base32": "^1.0.1",
+        "ripemd160": "^2.0.2",
+        "sha3": "^2.1.3"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -3045,6 +3064,41 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.0.tgz",
+      "integrity": "sha512-LM4jS5n33bJN60fM5EC8VeyhUgga6/DjCPBV2vWjnfVtobqtOiNC4SQ1MRFqyBSmJGGdB533JZWewyvlcdJtkQ==",
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.3.tgz",
+      "integrity": "sha512-0apCbwc8xAaie6W7q6QyogfyRS2BMU816a8KwpnpRw9Qrc6Bws+l7J3LfCLMt2iL6Wi8CYb0B29AeIr2N4vHnw==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.0-beta.2",
+        "async": "^3.2.4",
+        "ethereum-cryptography": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -4174,9 +4228,9 @@
       }
     },
     "node_modules/@jest/environment/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4186,7 +4240,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4267,9 +4320,9 @@
       }
     },
     "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4279,7 +4332,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4863,6 +4915,38 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
       "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
     },
+    "node_modules/@metamask/eth-sig-util": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz",
+      "integrity": "sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==",
+      "dependencies": {
+        "@ethereumjs/util": "^8.0.0",
+        "bn.js": "^4.11.8",
+        "ethereum-cryptography": "^1.1.2",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
@@ -5409,6 +5493,28 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6698,6 +6804,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.1",
+        "@noble/secp256k1": "~1.6.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.1",
+        "@scure/base": "~1.1.0"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -6720,24 +6868,24 @@
       "peer": true
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
+      "version": "0.24.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
+      "integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
@@ -7529,7 +7677,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7807,7 +7954,6 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
       "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -7955,8 +8101,7 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
@@ -7980,8 +8125,7 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-      "dev": true
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -9291,8 +9435,7 @@
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "dev": true
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "node_modules/abitype": {
       "version": "0.2.5",
@@ -9362,7 +9505,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -9382,7 +9524,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9397,7 +9538,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -9862,8 +10002,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.3",
-      "license": "MIT"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -9997,6 +10138,11 @@
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/b4a": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.1.tgz",
+      "integrity": "sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA=="
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -10434,6 +10580,24 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "dependencies": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/blakejs": {
@@ -11508,6 +11672,28 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-addr-codec": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
+      "integrity": "sha512-X4hzfBzNhy4mAc3UpiXEC/L0jo5E8wAa9unsnA8nNXYzXjCcGk83hfC5avJWCSGT8V91xMnAS9AKMHmjw5+XCg==",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "big-integer": "1.6.36",
+        "blakejs": "^1.1.0",
+        "bs58": "^4.0.1",
+        "ripemd160-min": "0.0.6",
+        "safe-buffer": "^5.2.0",
+        "sha3": "^2.1.1"
+      }
+    },
+    "node_modules/crypto-addr-codec/node_modules/big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -11672,14 +11858,12 @@
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -11690,8 +11874,7 @@
     "node_modules/cssstyle/node_modules/cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -11994,7 +12177,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -12008,7 +12190,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -12020,7 +12201,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -12029,7 +12209,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -12072,8 +12251,7 @@
     "node_modules/decimal.js": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
-      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
-      "dev": true
+      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -12099,7 +12277,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -12429,7 +12606,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
@@ -12441,7 +12617,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -12475,6 +12650,33 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotbit": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/dotbit/-/dotbit-0.4.14.tgz",
+      "integrity": "sha512-aT74qgjETFRUz+7buDLZNRkOucADfU/RRjkwAPyBEu3ZPTLcOXlhHyjRXMLP6ALDfZjk+TbMmBZVel2SVr4ddA==",
+      "dependencies": {
+        "@ensdomains/address-encoder": "^0.2.18",
+        "@ethersproject/providers": "^5.7.2",
+        "@metamask/eth-sig-util": "^5.0.2",
+        "blake2b": "^2.1.4",
+        "cross-fetch": "^3.1.5",
+        "ethers": "^5.6.9",
+        "grapheme-splitter": "^1.0.4",
+        "jest-environment-jsdom": "^29.3.1",
+        "type-fest": "^2.16.0"
+      }
+    },
+    "node_modules/dotbit/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/duplexify": {
@@ -12634,7 +12836,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmmirror.com/entities/-/entities-4.4.0.tgz",
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -12802,7 +13003,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
       "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -12824,7 +13024,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -12837,7 +13036,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -12854,7 +13052,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -12863,7 +13060,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12873,7 +13069,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -14184,7 +14379,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-redact": {
@@ -14814,7 +15008,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/graphql": {
@@ -15071,7 +15264,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -15123,7 +15315,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -15152,7 +15343,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -15217,7 +15407,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -15786,8 +15975,7 @@
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -17046,9 +17234,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17058,7 +17246,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17468,9 +17655,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17480,7 +17667,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17510,7 +17696,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -17521,8 +17706,7 @@
     "node_modules/jest-message-util/node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/jest-mock": {
       "version": "29.4.3",
@@ -17556,9 +17740,9 @@
       }
     },
     "node_modules/jest-mock/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17568,7 +17752,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -18496,16 +18679,31 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-crc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/js-crc/-/js-crc-0.2.0.tgz",
+      "integrity": "sha512-8DdCSAOACpF8WDAjyDFBC2rj8OS4HUP9mNZBDfl8jCiPCnJG+2bkuycalxwZh6heFy6PrMvoWTp47lp6gzT65A=="
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmmirror.com/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "license": "MIT"
+    },
+    "node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -18739,7 +18937,6 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.1.tgz",
       "integrity": "sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==",
-      "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.0",
@@ -18784,7 +18981,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -18798,7 +18994,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
       "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
-      "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -18813,7 +19008,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -18825,7 +19019,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -18834,7 +19027,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -18843,7 +19035,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -18856,7 +19047,6 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
       "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20597,6 +20787,11 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
+    "node_modules/nano-base32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
+      "integrity": "sha512-sxEtoTqAPdjWVGv71Q17koMFGsOMSiHsIFEvzOM7cNp8BXB4AnEwmDabm5dorusJf/v1z7QxaZYxUorU9RKaAw=="
+    },
     "node_modules/nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/nano-time/-/nano-time-1.0.0.tgz",
@@ -20605,6 +20800,11 @@
       "dependencies": {
         "big-integer": "^1.6.16"
       }
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -20945,8 +21145,7 @@
     "node_modules/nwsapi": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
-      "dev": true
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -21456,7 +21655,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
       "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-      "dev": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -22495,7 +22693,6 @@
     },
     "node_modules/psl": {
       "version": "1.8.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -22561,8 +22758,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -23107,8 +23303,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -23234,6 +23429,14 @@
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/ripemd160-min": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+      "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rlp": {
@@ -23451,7 +23654,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -23475,7 +23677,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -23713,6 +23914,14 @@
       },
       "bin": {
         "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "dependencies": {
+        "buffer": "6.0.3"
       }
     },
     "node_modules/shallow-clone": {
@@ -24161,7 +24370,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
       "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -24173,7 +24381,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -24616,8 +24823,7 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -25110,6 +25316,11 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
@@ -25127,7 +25338,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -25443,7 +25653,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -25604,7 +25813,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
       "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
-      "dev": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
@@ -25785,7 +25993,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -25803,7 +26010,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -25923,7 +26129,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26255,7 +26460,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -26263,8 +26467,7 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -28219,6 +28422,24 @@
       "resolved": "https://registry.npmmirror.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
+    "@ensdomains/address-encoder": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@ensdomains/address-encoder/-/address-encoder-0.2.20.tgz",
+      "integrity": "sha512-itaFxXavhdEnDcB2MuESzF9DDFb4xTNm5GyJu+MqzyplOKr6KtQBnj2LtH95qXpFxFhXQHoArOlGb/dfhkwfAg==",
+      "requires": {
+        "bech32": "^2.0.0",
+        "blakejs": "^1.1.0",
+        "bn.js": "^4.11.8",
+        "bs58": "^4.0.1",
+        "crypto-addr-codec": "^0.1.7",
+        "js-crc": "^0.2.0",
+        "js-sha256": "^0.9.0",
+        "js-sha512": "^0.8.0",
+        "nano-base32": "^1.0.1",
+        "ripemd160": "^2.0.2",
+        "sha3": "^2.1.3"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -28258,6 +28479,34 @@
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@ethereumjs/rlp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.0.tgz",
+      "integrity": "sha512-LM4jS5n33bJN60fM5EC8VeyhUgga6/DjCPBV2vWjnfVtobqtOiNC4SQ1MRFqyBSmJGGdB533JZWewyvlcdJtkQ=="
+    },
+    "@ethereumjs/util": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.3.tgz",
+      "integrity": "sha512-0apCbwc8xAaie6W7q6QyogfyRS2BMU816a8KwpnpRw9Qrc6Bws+l7J3LfCLMt2iL6Wi8CYb0B29AeIr2N4vHnw==",
+      "requires": {
+        "@ethereumjs/rlp": "^4.0.0-beta.2",
+        "async": "^3.2.4",
+        "ethereum-cryptography": "^1.1.2"
+      },
+      "dependencies": {
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
           }
         }
       }
@@ -28973,9 +29222,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -28985,7 +29234,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -29049,9 +29297,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -29061,7 +29309,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -29531,6 +29778,37 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
       "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
     },
+    "@metamask/eth-sig-util": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz",
+      "integrity": "sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==",
+      "requires": {
+        "@ethereumjs/util": "^8.0.0",
+        "bn.js": "^4.11.8",
+        "ethereum-cryptography": "^1.1.2",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "dependencies": {
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
@@ -29785,6 +30063,16 @@
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
       "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
       "optional": true
+    },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -30775,6 +31063,30 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
       "dev": true
     },
+    "@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
+    },
+    "@scure/bip32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "requires": {
+        "@noble/hashes": "~1.1.1",
+        "@noble/secp256k1": "~1.6.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "requires": {
+        "@noble/hashes": "~1.1.1",
+        "@scure/base": "~1.1.0"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -30797,24 +31109,24 @@
       "peer": true
     },
     "@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
+      "version": "0.24.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
+      "integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0"
@@ -31379,8 +31691,7 @@
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
     "@trysound/sax": {
       "version": "0.2.0",
@@ -31636,7 +31947,6 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
       "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -31772,8 +32082,7 @@
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.5",
@@ -31796,8 +32105,7 @@
     "@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-      "dev": true
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
     },
     "@types/trusted-types": {
       "version": "2.0.2",
@@ -32883,8 +33191,7 @@
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "dev": true
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "abitype": {
       "version": "0.2.5",
@@ -32924,7 +33231,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
       "requires": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -32940,8 +33246,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "aes-js": {
       "version": "3.0.0",
@@ -32952,7 +33257,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -33271,7 +33575,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.3"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -33356,6 +33662,11 @@
       "resolved": "https://registry.npmmirror.com/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
+    },
+    "b4a": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.1.tgz",
+      "integrity": "sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA=="
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
@@ -33679,6 +33990,24 @@
             "ieee754": "^1.1.13"
           }
         }
+      }
+    },
+    "blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "requires": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "requires": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
       }
     },
     "blakejs": {
@@ -34489,6 +34818,27 @@
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "dev": true
     },
+    "crypto-addr-codec": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
+      "integrity": "sha512-X4hzfBzNhy4mAc3UpiXEC/L0jo5E8wAa9unsnA8nNXYzXjCcGk83hfC5avJWCSGT8V91xMnAS9AKMHmjw5+XCg==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "big-integer": "1.6.36",
+        "blakejs": "^1.1.0",
+        "bs58": "^4.0.1",
+        "ripemd160-min": "0.0.6",
+        "safe-buffer": "^5.2.0",
+        "sha3": "^2.1.1"
+      },
+      "dependencies": {
+        "big-integer": {
+          "version": "1.6.36",
+          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+          "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+        }
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -34587,14 +34937,12 @@
     "cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
       "requires": {
         "cssom": "~0.3.6"
       },
@@ -34602,8 +34950,7 @@
         "cssom": {
           "version": "0.3.8",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-          "dev": true
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         }
       }
     },
@@ -34825,7 +35172,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -34836,7 +35182,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
           "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "dev": true,
           "requires": {
             "punycode": "^2.1.1"
           }
@@ -34844,14 +35189,12 @@
         "webidl-conversions": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-          "dev": true
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-url": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
           "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "dev": true,
           "requires": {
             "tr46": "^3.0.0",
             "webidl-conversions": "^7.0.0"
@@ -34880,8 +35223,7 @@
     "decimal.js": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
-      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
-      "dev": true
+      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
     },
     "decimal.js-light": {
       "version": "2.5.1",
@@ -34902,8 +35244,7 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -35136,7 +35477,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
       "requires": {
         "webidl-conversions": "^7.0.0"
       },
@@ -35144,8 +35484,7 @@
         "webidl-conversions": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-          "dev": true
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         }
       }
     },
@@ -35167,6 +35506,29 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      }
+    },
+    "dotbit": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/dotbit/-/dotbit-0.4.14.tgz",
+      "integrity": "sha512-aT74qgjETFRUz+7buDLZNRkOucADfU/RRjkwAPyBEu3ZPTLcOXlhHyjRXMLP6ALDfZjk+TbMmBZVel2SVr4ddA==",
+      "requires": {
+        "@ensdomains/address-encoder": "^0.2.18",
+        "@ethersproject/providers": "^5.7.2",
+        "@metamask/eth-sig-util": "^5.0.2",
+        "blake2b": "^2.1.4",
+        "cross-fetch": "^3.1.5",
+        "ethers": "^5.6.9",
+        "grapheme-splitter": "^1.0.4",
+        "jest-environment-jsdom": "^29.3.1",
+        "type-fest": "^2.16.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "duplexify": {
@@ -35290,8 +35652,7 @@
     "entities": {
       "version": "4.4.0",
       "resolved": "https://registry.npmmirror.com/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -35417,7 +35778,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
       "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -35430,7 +35790,6 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-          "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2"
@@ -35440,7 +35799,6 @@
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -35453,21 +35811,18 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-          "dev": true
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         },
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-          "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
           }
@@ -36474,8 +36829,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-redact": {
       "version": "3.1.2",
@@ -36902,8 +37256,7 @@
     "grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "graphql": {
       "version": "16.6.0",
@@ -37095,7 +37448,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "^2.0.0"
       }
@@ -37139,7 +37491,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
       "requires": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -37161,7 +37512,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -37196,7 +37546,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -37561,8 +37910,7 @@
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -38513,9 +38861,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -38525,7 +38873,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -38848,9 +39195,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -38860,7 +39207,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -38880,16 +39226,14 @@
             "ansi-styles": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
             }
           }
         },
         "react-is": {
           "version": "18.2.0",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },
@@ -38919,9 +39263,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -38931,7 +39275,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -39632,14 +39975,29 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "js-crc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/js-crc/-/js-crc-0.2.0.tgz",
+      "integrity": "sha512-8DdCSAOACpF8WDAjyDFBC2rj8OS4HUP9mNZBDfl8jCiPCnJG+2bkuycalxwZh6heFy6PrMvoWTp47lp6gzT65A=="
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "dev": true
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmmirror.com/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
+    "js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -39833,7 +40191,6 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.1.tgz",
       "integrity": "sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.6",
         "acorn": "^8.8.0",
@@ -39867,7 +40224,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -39878,7 +40234,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
           "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.33",
             "punycode": "^2.1.1",
@@ -39890,7 +40245,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
           "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "dev": true,
           "requires": {
             "punycode": "^2.1.1"
           }
@@ -39898,20 +40252,17 @@
         "universalify": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-          "dev": true
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
         },
         "webidl-conversions": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-          "dev": true
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-url": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
           "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "dev": true,
           "requires": {
             "tr46": "^3.0.0",
             "webidl-conversions": "^7.0.0"
@@ -39921,7 +40272,6 @@
           "version": "8.9.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
           "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-          "dev": true,
           "requires": {}
         }
       }
@@ -41225,6 +41575,11 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
+    "nano-base32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
+      "integrity": "sha512-sxEtoTqAPdjWVGv71Q17koMFGsOMSiHsIFEvzOM7cNp8BXB4AnEwmDabm5dorusJf/v1z7QxaZYxUorU9RKaAw=="
+    },
     "nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/nano-time/-/nano-time-1.0.0.tgz",
@@ -41232,6 +41587,11 @@
       "requires": {
         "big-integer": "^1.6.16"
       }
+    },
+    "nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -41436,8 +41796,7 @@
     "nwsapi": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
-      "dev": true
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "nyc": {
       "version": "15.1.0",
@@ -41803,7 +42162,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
       "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-      "dev": true,
       "requires": {
         "entities": "^4.4.0"
       }
@@ -42445,8 +42803,7 @@
       "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "dev": true
+      "version": "1.8.0"
     },
     "pump": {
       "version": "3.0.0",
@@ -42490,8 +42847,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -42879,8 +43235,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -42967,6 +43322,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "ripemd160-min": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+      "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A=="
     },
     "rlp": {
       "version": "2.2.7",
@@ -43108,8 +43468,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
       "version": "1.58.0",
@@ -43126,7 +43485,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -43314,6 +43672,14 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "requires": {
+        "buffer": "6.0.3"
       }
     },
     "shallow-clone": {
@@ -43664,7 +44030,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
       "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -43672,8 +44037,7 @@
         "escape-string-regexp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         }
       }
     },
@@ -43995,8 +44359,7 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tapable": {
       "version": "2.2.1",
@@ -44355,6 +44718,11 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
+    "tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
@@ -44367,8 +44735,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.20.2",
@@ -44586,7 +44953,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -44716,7 +45082,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
       "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
-      "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
       }
@@ -44836,7 +45201,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.6.3"
       }
@@ -44850,8 +45214,7 @@
     "whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
     },
     "whatwg-url": {
       "version": "5.0.0",
@@ -44930,8 +45293,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workbox-background-sync": {
       "version": "6.5.3",
@@ -45190,14 +45552,12 @@
     "xml-name-validator": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4231,7 +4231,6 @@
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
       "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -4320,10 +4319,9 @@
       }
     },
     "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -6868,25 +6866,22 @@
       "peer": true
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
-      "integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
-      "dev": true
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-      "dev": true,
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
@@ -17234,10 +17229,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -17655,10 +17649,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@types/yargs": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -17740,10 +17733,9 @@
       }
     },
     "node_modules/jest-mock/node_modules/@types/yargs": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -29225,7 +29217,6 @@
           "version": "17.0.13",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
           "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -29297,10 +29288,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-          "dev": true,
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -31109,25 +31099,22 @@
       "peer": true
     },
     "@sinclair/typebox": {
-      "version": "0.24.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
-      "integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
-      "dev": true
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-      "dev": true,
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "requires": {
         "@sinonjs/commons": "^2.0.0"
       }
@@ -38861,10 +38848,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-          "dev": true,
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -39195,10 +39181,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-          "dev": true,
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -39263,10 +39248,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-          "dev": true,
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nervosnetwork/ckb-sdk-utils": "0.103.1",
     "bignumber.js": "9.1.1",
     "dayjs": "1.11.7",
+    "dotbit": "0.4.14",
     "ethers": "5.7.2",
     "graphql": "16.6.0",
     "graphql-request": "5.1.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,6 +92,10 @@ const queryHomeLists = gql`
         polyjuice {
           status
           native_transfer_address_hash
+          native_transfer_account {
+            bit_alias
+            eth_address
+          }
         }
         type
       }
@@ -116,7 +120,7 @@ interface HomeLists {
       type: GraphQLSchema.TransactionType
       from_account: Pick<GraphQLSchema.Account, 'eth_address' | 'script_hash' | 'type' | 'bit_alias'>
       to_account: Pick<GraphQLSchema.Account, 'eth_address' | 'script_hash' | 'type' | 'bit_alias'>
-      polyjuice: Pick<GraphQLSchema.Polyjuice, 'status' | 'native_transfer_address_hash'>
+      polyjuice: Pick<GraphQLSchema.Polyjuice, 'status' | 'native_transfer_address_hash' | 'native_transfer_account'>
     }>
   }
 }
@@ -453,14 +457,15 @@ const TxList: React.FC<{ list: HomeLists['transactions']['entries']; isLoading: 
       {list?.slice(0, length).map((tx, idx) => {
         const hash = tx.eth_hash ?? tx.hash
         const from = tx.from_account.eth_address || tx.from_account.script_hash
+        const from_bit_alias = tx.from_account?.bit_alias
+
         let to = tx.to_account?.eth_address || tx.to_account?.script_hash || '-'
+        let to_bit_alias = tx.to_account?.bit_alias
         let toType = tx.to_account?.type
 
-        const from_bit_alias = tx.from_account?.bit_alias
-        const to_bit_alias = tx.to_account?.bit_alias
-
-        if (tx.polyjuice?.native_transfer_address_hash) {
-          to = tx.polyjuice.native_transfer_address_hash
+        if (tx.polyjuice?.native_transfer_account) {
+          to = tx.polyjuice.native_transfer_account.eth_address
+          to_bit_alias = tx.polyjuice.native_transfer_account.bit_alias
           toType = GraphQLSchema.AccountType.EthUser
         }
         const isSpecialFrom = SPECIAL_ADDR_TYPES.includes(tx.from_account.type)

--- a/pages/multi-token-item/[...id].tsx
+++ b/pages/multi-token-item/[...id].tsx
@@ -226,7 +226,7 @@ const MultiTokenItem = () => {
                     token_id,
                     contract_address_hash: address,
                     counts: item.quantity.toString(),
-                    owner: item.address_hash,
+                    owner: item,
                     token_instance: {
                       metadata: {
                         image: imageUrl,

--- a/pages/nft-item/[...id].tsx
+++ b/pages/nft-item/[...id].tsx
@@ -194,7 +194,6 @@ const NftItem = () => {
       <div className={styles.container}>
         <div className={styles.overview}>
           <img
-            className={styles.logo}
             src={getIpfsUrl(metadata?.image ?? '/images/nft-placeholder.svg')}
             onError={handleNftImageLoadError}
             alt="nft-cover"

--- a/pages/nft-item/styles.module.scss
+++ b/pages/nft-item/styles.module.scss
@@ -19,6 +19,9 @@
     justify-content: space-between;
     padding-bottom: 2rem;
     padding-left: 2rem;
+    .owner {
+      display: flex;
+    }
   }
   h2 {
     margin: 0;
@@ -45,7 +48,7 @@
     }
   }
 
-  img {
+  .logo {
     width: 440px;
     height: 440px;
     object-fit: cover;

--- a/pages/nft-item/styles.module.scss
+++ b/pages/nft-item/styles.module.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  .logo {
+  img {
     width: 440px;
     height: 440px;
     object-fit: cover;

--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -73,6 +73,7 @@ interface Transaction {
     | 'max_fee_per_gas'
     | 'max_priority_fee_per_gas'
     | 'paymaster_and_data'
+    | 'native_transfer_account'
   > | null
   polyjuice_creator: Pick<GraphQLSchema.PolyjuiceCreator, 'created_account'> | null
   block: Pick<GraphQLSchema.Block, 'number' | 'hash' | 'timestamp' | 'status' | 'layer1_block_number'>
@@ -118,6 +119,10 @@ const txQuery = gql`
       max_fee_per_gas
       max_priority_fee_per_gas
       paymaster_and_data
+      native_transfer_account {
+        bit_alias
+        eth_address
+      }
     }
     polyjuice_creator {
       created_account {
@@ -293,9 +298,11 @@ const Tx = () => {
   }
 
   const fromAddrDisplay = getAddressDisplay(tx?.from_account)
-  const toAddrDisplay = getAddressDisplay(tx?.to_account, tx?.polyjuice?.native_transfer_address_hash)
+  const toAddrDisplay = getAddressDisplay(tx?.to_account, tx?.polyjuice?.native_transfer_account?.eth_address)
+
   const method = tx?.method_name ?? tx?.method_id
   const from_bit_alias = tx?.from_account?.bit_alias
+  const to_bit_alias = tx?.polyjuice?.native_transfer_account?.bit_alias
 
   const overview: InfoItemProps[] = [
     {
@@ -324,7 +331,14 @@ const Tx = () => {
       content: isTxLoading ? (
         <Skeleton animation="wave" />
       ) : tx ? (
-        <ResponsiveHash label={toAddrDisplay.label} href={`/address/${toAddrDisplay.address}`} />
+        to_bit_alias ? (
+          <HashLink
+            label={to_bit_alias ? <Address address={toAddrDisplay.label} domain={to_bit_alias} /> : toAddrDisplay.label}
+            href={`/address/${toAddrDisplay.address}`}
+          />
+        ) : (
+          <ResponsiveHash label={toAddrDisplay.label} href={`/address/${toAddrDisplay.address}`} />
+        )
       ) : (
         t('pending')
       ),

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,7 +8,8 @@ export const API_ENDPOINT = `https://${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/
 export const WS_ENDPOINT = `wss://${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/socket`
 export const GRAPHQL_ENDPOINT = `https://${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/graphql`
 export const NODE_URL = process.env.NEXT_PUBLIC_NODE_URL
-export const DOMAIN_LOGO_BASE_URL = 'https://identicons.did.id/identicon/'
+export const BIT_LOGO_BASE_URL = 'https://identicons.did.id/identicon/'
+export const BIT_DATA_BASE_URL = 'https://data.did.id/'
 
 export const EXPLORER_TITLE = process.env.NEXT_PUBLIC_EXPLORER_TITLE
 export const IS_MAINNET = process.env.NEXT_PUBLIC_CHAIN_TYPE === 'mainnet'

--- a/utils/graphql.ts
+++ b/utils/graphql.ts
@@ -125,6 +125,22 @@ export namespace GraphQLSchema {
     balance: string
   }
 
+  export interface PolyjuiceAccount {
+    bit_alias: string
+    bridged_udt: Udt
+    contract_code: string
+    eth_address: string
+    id: number
+    nonce: number
+    registry_address: string
+    script: object
+    script_hash: string
+    smart_contract: SmartContract
+    token_transfer_count: number
+    transaction_count: number
+    type: AccountType
+    udt: Udt
+  }
   export interface Polyjuice {
     gas_limit: number
     gas_price: string
@@ -145,6 +161,7 @@ export namespace GraphQLSchema {
     max_fee_per_gas: string
     max_priority_fee_per_gas: string
     paymaster_and_data: string
+    native_transfer_account: PolyjuiceAccount
   }
 
   export interface PolyjuiceCreator {

--- a/utils/handler.ts
+++ b/utils/handler.ts
@@ -36,7 +36,8 @@ export const handleSearchKeyPress = async (e: React.KeyboardEvent<HTMLInputEleme
 
   // A non-number, could be a token name
   // Redirect to the `search-result-tokens` list page, uses `search_udt` query to fetch a list
-  if (Number.isNaN(+search)) {
+  // .bit need to be skiped to the keywordsearch
+  if (Number.isNaN(+search) && !search.endsWith('.bit')) {
     push(`/search-result-tokens?search=${encodeURIComponent(search)}`)
     return
   }


### PR DESCRIPTION
What problem does this PR solve?
------

## 1 
1-1、 support searching ends with `.bit`
1-2、the .bit domain tag on the account page should be a `link` to .bit account page

<img width="500" alt="image" src="https://user-images.githubusercontent.com/22511289/211251396-7a6517c4-55cc-4792-ac61-5f07bfebf33d.png">

## 2
2-1、 showing magickbase.bit on hovering .bit icon is redundant, now showing text `.bit Name`

<img width="500" alt="image" src="https://user-images.githubusercontent.com/22511289/211251483-3471b309-b289-4326-a23b-cf842314be6b.png">

## 3
3-1、 token/holder list, magickbase.bit is not displayed ( `not include in this PR`)
https://v1.gwscan.com/token/133?tab=holders&id=133&page=13
3-2、 nft-collection, in the inventory, owner is not displayed by .bit name https://v1.gwscan.com/nft-collection/0x73c0e2a4b765ed81f63759d1fcf2c4dcd2925f4a?tab=inventory
3-3、nft-item, owner is not displayed with .bit name
https://v1.gwscan.com/nft-item/0x73c0e2a4b765ed81f63759d1fcf2c4dcd2925f4a/2375

<img width="500" alt="image" src="https://user-images.githubusercontent.com/22511289/211251429-0eeb9228-7cc5-440a-a8f6-5a076560fcbd.png">


Ref: https://github.com/Magickbase/godwoken_explorer/issues/1170

Check List
------

### Test
e2e Test
### Task
none
