### PR TITLE
Fix: Wrong format eth address also display page 

### DIFF
--- a/components/AccountOverview/index.tsx
+++ b/components/AccountOverview/index.tsx
@@ -197,12 +197,9 @@ const fetchAccount = (variables: Variables, fetchApi) =>
         nonce: 0,
       } as UnknownUser),
   )
-
 export const fetchAccountOverview = (variables: Variables) => fetchAccount(variables, accountOverviewQuery)
 export const fetchAccountOverviewUnion = (variables: Variables) => fetchAccount(variables, accountOverviewQueryUnion)
-
 export const fetchAccountBalance = (address: string) => provider.getBalance(address).then(res => res.toString())
-
 export const fetchDeployAddress = (variables: { eth_hash: string }) =>
   client
     .request<{ transaction: { from_account: Pick<GraphQLSchema.Account, 'eth_address' | 'bit_alias'> } }>(

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -37,8 +37,6 @@ import { WagmiConfig } from 'wagmi'
 
 import styles from './styles.module.scss'
 
-const createKeccakHash = require('keccak')
-
 const isSmartContractAccount = (account: AccountOverviewProps['account']): account is PolyjuiceContract => {
   return !!(account as PolyjuiceContract)?.smart_contract
 }
@@ -312,7 +310,6 @@ const Account = () => {
         <div className={styles.title}>
           <PageTitle>
             {title}
-
             {!checkAddressIsValid(id as string) && (
               <div className={styles['invalid-tips']}>
                 <span>{t('invalidAddress')}</span>

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -294,29 +294,12 @@ const Account = () => {
     [GraphQLSchema.AccountType.PolyjuiceContract].includes(accountType) ? { label: t('events'), key: 'events' } : null,
   ].filter(v => v)
 
-  const toChecksumAddress = (address: string) => {
-    address = address.toLowerCase().slice(2)
-    let hash = createKeccakHash('keccak256').update(address).digest('hex')
-    let ret = '0x'
-
-    for (let i = 0; i < address.length; i++) {
-      if (parseInt(hash[i], 16) >= 8) {
-        ret += address[i].toUpperCase()
-      } else {
-        ret += address[i]
-      }
-    }
-
-    return ret
-  }
-
   const checkAddressIsValid = (address: string) => {
     const len = address?.length || 0
 
+    // for now, we skipped checking godwoken-script-hash
     if (len == 66) {
-      const sumResult = toChecksumAddress(address)
-      const uppercasedAddress = address.toUpperCase().slice(2)
-      return address.toLowerCase() === address || `0x${uppercasedAddress}` === address || address === sumResult
+      return address.startsWith('0x')
     } else {
       return isEthAddress(id as string)
     }
@@ -329,7 +312,7 @@ const Account = () => {
         <div className={styles.title}>
           <PageTitle>
             {title}
-            {/* for now, we only should check eth_address */}
+
             {!checkAddressIsValid(id as string) && (
               <div className={styles['invalid-tips']}>
                 <span>{t('invalidAddress')}</span>

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -61,8 +61,10 @@ const Account = () => {
       age_range_end = null,
       method_id = null,
       method_name = null,
+      search = '',
     },
   } = useRouter()
+
   const [t] = useTranslation(['account', 'common'])
   const q = isEthAddress(id as string) ? { address: id as string } : { script_hash: id as string }
 
@@ -303,7 +305,16 @@ const Account = () => {
       <SubpageHead subtitle={account ? `${title} ${id}` : (id as string)} />
       <div className={styles.container}>
         <div className={styles.title}>
-          <PageTitle>{title}</PageTitle>
+          <PageTitle>
+            {title}
+            {search ? (
+              isEthAddress(search as string) ? null : (
+                <div className={styles['invalid-tips']}>
+                  <span>{t('invalidAddress')}</span>
+                </div>
+              )
+            ) : null}
+          </PageTitle>
           {downloadItems.length ? <DownloadMenu items={downloadItems} /> : null}
         </div>
         <div className={styles.hash}>

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -315,7 +315,8 @@ const Account = () => {
 
     if (len == 66) {
       const sumResult = toChecksumAddress(address)
-      return address.toLowerCase() === address || address === sumResult
+      const uppercasedAddress = address.toUpperCase().slice(2)
+      return address.toLowerCase() === address || `0x${uppercasedAddress}` === address || address === sumResult
     } else {
       return isEthAddress(id as string)
     }

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -261,15 +261,7 @@ const Account = () => {
     : []
 
   const accountType = account?.type
-  const title = account ? (
-    accountType ? (
-      t(`accountType.${accountType}`)
-    ) : (
-      t(`accountType.UNKNOWN`)
-    )
-  ) : (
-    <Skeleton animation="wave" width="200px" />
-  )
+  const title = accountType ? t(`accountType.${accountType}`) : t(`accountType.UNKNOWN`)
 
   const tabs = [
     { label: t('transactionRecords'), key: 'transactions' },

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -61,7 +61,6 @@ const Account = () => {
       age_range_end = null,
       method_id = null,
       method_name = null,
-      search = '',
     },
   } = useRouter()
 
@@ -307,13 +306,11 @@ const Account = () => {
         <div className={styles.title}>
           <PageTitle>
             {title}
-            {search ? (
-              isEthAddress(search as string) ? null : (
-                <div className={styles['invalid-tips']}>
-                  <span>{t('invalidAddress')}</span>
-                </div>
-              )
-            ) : null}
+            {!isEthAddress(id as string) && (
+              <div className={styles['invalid-tips']}>
+                <span>{t('invalidAddress')}</span>
+              </div>
+            )}
           </PageTitle>
           {downloadItems.length ? <DownloadMenu items={downloadItems} /> : null}
         </div>

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -306,7 +306,8 @@ const Account = () => {
         <div className={styles.title}>
           <PageTitle>
             {title}
-            {!isEthAddress(id as string) && (
+            {/* for now, we only should check eth_address */}
+            {!isEthAddress(id as string) && id?.length !== 66 && (
               <div className={styles['invalid-tips']}>
                 <span>{t('invalidAddress')}</span>
               </div>

--- a/pages/account/styles.module.scss
+++ b/pages/account/styles.module.scss
@@ -12,9 +12,25 @@
     h5 {
       margin: 0;
     }
+
+    .invalid-tips {
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 16px;
+      border-radius: 4px;
+      padding: 4px;
+      background: #fcf0f0;
+      margin-left: 8px;
+      color: #f83f3f;
+    }
+
     @media screen and (max-width: 1024px) {
       margin-top: 0.5rem;
       margin-bottom: 4px;
+
+      .invalid-tips {
+        margin-left: 5px;
+      }
     }
   }
 

--- a/public/locales/en-US/account.json
+++ b/public/locales/en-US/account.json
@@ -92,5 +92,5 @@
   "erc721Assets": "ERC 721 Assets",
   "erc1155Assets": "ERC 1155 Assets",
   "erc20Assets": "ERC 20 Assets",
-  "invalidAddress": "*invalid address format"
+  "invalidAddress": "*Invalid address format"
 }

--- a/public/locales/en-US/account.json
+++ b/public/locales/en-US/account.json
@@ -91,5 +91,6 @@
   "ERC721": "ERC-721",
   "erc721Assets": "ERC 721 Assets",
   "erc1155Assets": "ERC 1155 Assets",
-  "erc20Assets": "ERC 20 Assets"
+  "erc20Assets": "ERC 20 Assets",
+  "invalidAddress": "*invalid address format"
 }

--- a/public/locales/zh-CN/account.json
+++ b/public/locales/zh-CN/account.json
@@ -91,5 +91,6 @@
   "ERC721": "ERC-721",
   "erc721Assets": "ERC 721 资产",
   "erc1155Assets": "ERC 1155 资产",
-  "erc20Assets": "ERC 20 资产"
+  "erc20Assets": "ERC 20 资产",
+  "invalidAddress": "*无效的地址格式"
 }


### PR DESCRIPTION
What problem does this PR solve?
------
When we search for an account with the wrong eth address and the page is also on the page `account`, we will get a warning tip.

<img width="831" alt="image" src="https://user-images.githubusercontent.com/22511289/211555692-87b8e740-d985-4016-9d8c-fcc7dc8a3014.png">


Figma: https://www.figma.com/file/6XNoimRDbFTTNm016rbIdU/Magickbase?node-id=9158%3A32271&t=9cVjv7wlAYVixl66-1
Ref: https://github.com/Magickbase/godwoken_explorer/issues/1225

Check List
------

### Test
e2e Test
### Task
none
