### PR TITLE
fix: text being clipped

### DIFF
--- a/pages/token/styles.module.scss
+++ b/pages/token/styles.module.scss
@@ -19,6 +19,7 @@
       margin-left: 0.5rem;
       overflow: hidden;
       text-overflow: ellipsis;
+      line-height: 1.1;
     }
     @media screen and (max-width: 1024px) {
       margin-bottom: 4px;


### PR DESCRIPTION
fix https://github.com/Magickbase/godwoken_explorer/issues/1259

text is being clipped:
![image](https://user-images.githubusercontent.com/32790369/212040439-7f102076-0185-4c0a-8646-8f51c5fce79b.png)

fix:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/32790369/212040327-b09cc6e4-bb43-413e-99cd-d19c05f87bcc.png">
