### PR TITLE
Fix: Alignment of addresses in transaction list is weird

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -473,7 +473,7 @@ const TxList: React.FC<{ list: HomeLists['transactions']['entries']; isLoading: 
                 primary={
                   <Stack direction="row" alignItems="center" sx={{ height: { xs: 52, md: 88 } }}>
                     <Stack
-                      flexGrow={1}
+                      flex={1}
                       px={{ xs: 1, md: 2 }}
                       justifyContent={{ xs: 'center', md: 'space-between' }}
                       height={{ xs: 36, md: 56 }}
@@ -528,6 +528,7 @@ const TxList: React.FC<{ list: HomeLists['transactions']['entries']; isLoading: 
                       </Box>
                     </Stack>
                     <Stack
+                      flex={1}
                       height={{ xs: 36, md: 56 }}
                       sx={{ pl: { xs: 1, sm: 0 } }}
                       justifyContent={{ xs: 'center', md: 'space-between' }}


### PR DESCRIPTION
What problem does this PR solve?
------
Before:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/22511289/212364628-b6caf390-b89a-4614-af2c-7477e3b2d86f.png">

After:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/22511289/212364866-bb5305c8-7f06-4988-90b9-64d1b629ba03.png">


Ref: https://github.com/Magickbase/godwoken_explorer/issues/1278

Check List
------

### Test
e2e Test
### Task
none
