### PR TITLE
feat: optimize style of tooltip

### DIFF
--- a/components/DownloadMenu/styles.module.scss
+++ b/components/DownloadMenu/styles.module.scss
@@ -7,8 +7,6 @@
 
   :global(.tooltip::before) {
     white-space: nowrap;
-    width: 300px;
-    max-width: unset;
     @media screen and (max-width: 1440px) {
       transform: translate(-80%, -100%);
     }

--- a/components/DownloadMenu/styles.module.scss
+++ b/components/DownloadMenu/styles.module.scss
@@ -5,6 +5,15 @@
   font-family: Roboto;
   z-index: 99;
 
+  :global(.tooltip::before) {
+    white-space: nowrap;
+    width: 300px;
+    max-width: unset;
+    @media screen and (max-width: 1440px) {
+      transform: translate(-80%, -100%);
+    }
+  }
+
   label {
     display: flex;
     justify-content: center;

--- a/components/SmartContractInfo/index.tsx
+++ b/components/SmartContractInfo/index.tsx
@@ -192,7 +192,7 @@ const SmartContract: React.FC<{
             </a>
           ) : null}
           {isSubmitted ? (
-            <div className="tooltip" data-tooltip={t('submitted')} key="submitted">
+            <div className={`tooltip ${styles.submitted}`} data-tooltip={t('submitted')} key="submitted">
               <SubmittedIcon />
             </div>
           ) : null}

--- a/components/SmartContractInfo/styles.module.scss
+++ b/components/SmartContractInfo/styles.module.scss
@@ -14,6 +14,15 @@
       filter: drop-shadow(0px 4px 8px rgba(0, 0, 0, 0.1));
     }
   }
+  :global(.tooltip::before) {
+    white-space: nowrap;
+  }
+
+  @media screen and (max-width: 1024px) {
+    .submitted::before {
+      transform: translate(-80%, -100%);
+    }
+  }
 }
 .item-dd-cls {
   color: var(--primary-color);

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -1,0 +1,8 @@
+.container {
+  .all::before {
+    white-space: nowrap;
+    @media screen and (max-width: 1280px) {
+      transform: translate(-80%, -100%);
+    }
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ import BlockStateIcon from 'components/BlockStateIcon'
 import TxStatusIcon from 'components/TxStatusIcon'
 import Address from 'components/TruncatedAddress'
 import { fetchHome, timeDistance, formatInt, client, GraphQLSchema, IS_MAINNET } from 'utils'
+import styles from './index.module.scss'
 
 type State = API.Home.Parsed
 
@@ -230,7 +231,7 @@ const ListContainer = ({ link, title, tooltip, children }) => {
           {title}
         </Typography>
         <NextLink href={link} passHref>
-          <div className="tooltip " data-tooltip={tooltip}>
+          <div className={`tooltip ${styles.all}`} data-tooltip={tooltip}>
             <Box sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
               <Typography variant="body2" fontSize={{ xs: 13, md: 14 }} fontWeight={500} color="primary">
                 {t('all')}
@@ -655,7 +656,7 @@ const Home = () => {
   })
 
   return (
-    <Box sx={{ pb: { xs: 5, md: 11 } }}>
+    <Box sx={{ pb: { xs: 5, md: 11 } }} className={styles.container}>
       <Box sx={{ bgcolor: 'primary.light' }}>
         <Container sx={{ px: { xs: 2, md: 2, lg: 0 } }}>
           <Search />

--- a/pages/token/[id].tsx
+++ b/pages/token/[id].tsx
@@ -345,12 +345,11 @@ const Token: React.FC<Props> = () => {
               <div className={styles.infoTitle}>
                 {t(`tokenInfo`)}
                 {token?.eth_type === 'ERC20' ? (
-                  <div className="tooltip" data-tooltip={t('import-token-into-metamask')}>
+                  <div className={`${'tooltip'} ${styles.metamask}`} data-tooltip={t('import-token-into-metamask')}>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src="/logos/metamask.png"
                       alt="MetaMask"
-                      className={styles.metamask}
                       title={t('import-token-into-metamask')}
                       onClick={handleImportIntoMetamask}
                     />

--- a/pages/token/styles.module.scss
+++ b/pages/token/styles.module.scss
@@ -123,12 +123,20 @@
 }
 
 .metamask {
-  width: 1.6rem;
-  height: 1.6rem;
-  cursor: pointer;
+  img {
+    width: 1.6rem;
+    height: 1.6rem;
+    cursor: pointer;
+    @media screen and (max-width: 1024px) {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+
   @media screen and (max-width: 1024px) {
-    width: 1.25rem;
-    height: 1.25rem;
+    &:hover::before {
+      transform: translate(-80%, -100%);
+    }
   }
 }
 

--- a/styles/tooltip.scss
+++ b/styles/tooltip.scss
@@ -16,8 +16,6 @@
   font-size: 0.875rem;
 
   &::before {
-    min-width: 100px;
-    max-width: 246px;
     padding: 8px;
     top: -16.5px;
     border-radius: 5px;
@@ -30,10 +28,6 @@
     display: none;
 
     @include tooltip-content-title;
-
-    @media screen and (max-width: 768px) {
-      max-width: 150px;
-    }
   }
   &::after {
     content: '';


### PR DESCRIPTION
1. make text unwrapped if it consists of several words
2. align tooltip to right border for mobile layout

Ref: https://github.com/Magickbase/godwoken_explorer/issues/1199

---
1. Homepage: https://godwoken-explorer-ui-git-short-tooltip-unwrapped-magickbase.vercel.app/
Before
![image](https://user-images.githubusercontent.com/7271329/212969363-c283a538-9331-4abc-be59-8bb732947c67.png)
After
![image](https://user-images.githubusercontent.com/7271329/212969402-724252ec-a5ec-475f-9500-396c75effb81.png)
![image](https://user-images.githubusercontent.com/7271329/212969527-b43e7470-99d6-4197-b298-395fc488ee4c.png)

2. Account page: https://godwoken-explorer-ui-git-short-tooltip-unwrapped-magickbase.vercel.app/account/0xbe65f55eab96cc2a64e7b509421900b62c15e0c6
Before
![image](https://user-images.githubusercontent.com/7271329/212969895-2f98235b-a87b-4339-b75a-fe0fa5db9486.png)
![image](https://user-images.githubusercontent.com/7271329/212969956-6a307a72-8cdc-4756-83d8-6e59ce35e77a.png)
After
![image](https://user-images.githubusercontent.com/7271329/212970057-73eb2ad5-dace-48a1-be65-c9626c74d8c0.png)
![image](https://user-images.githubusercontent.com/7271329/212970125-354b5031-c220-455c-99af-ca83b3c0af43.png)
![image](https://user-images.githubusercontent.com/7271329/212970163-17df5c10-9e11-4d36-921a-0b9f792b48d0.png)
![image](https://user-images.githubusercontent.com/7271329/212970213-a23e785f-f221-4b02-9d5a-e4de61eb4dbb.png)

3. Token page: https://godwoken-explorer-ui-git-short-tooltip-unwrapped-magickbase.vercel.app/token/375
Before
![image](https://user-images.githubusercontent.com/7271329/212970677-fd2479e6-872a-4f43-99e2-cf784933aa56.png)
After
![image](https://user-images.githubusercontent.com/7271329/212970780-76518c8e-152f-43ea-9254-427961c2e01e.png)

