### PR TITLE
fix: tx page ui improvements

### DIFF
--- a/cypress/integration/tx/index.spec.ts
+++ b/cypress/integration/tx/index.spec.ts
@@ -165,7 +165,7 @@ context('Transaction Page', () => {
           .find('dt')
           .should('have.text', 'Paymaster Data')
           .next()
-          .should('have.text', '1,234')
+          .should('have.text', '0x1234')
       })
 
       it('should have Call Data', () => {

--- a/cypress/integration/tx/index.spec.ts
+++ b/cypress/integration/tx/index.spec.ts
@@ -125,7 +125,7 @@ context('Transaction Page', () => {
           .find('dt')
           .should('have.text', 'Call Gas Limit')
           .next()
-          .should('have.text', '100000')
+          .should('have.text', '100,000')
       })
 
       it('should have Verification Gas Limit', () => {
@@ -133,7 +133,7 @@ context('Transaction Page', () => {
           .find('dt')
           .should('have.text', 'Verification Gas Limit')
           .next()
-          .should('have.text', '100000')
+          .should('have.text', '100,000')
       })
 
       it('should have Paymaster', () => {
@@ -165,7 +165,7 @@ context('Transaction Page', () => {
           .find('dt')
           .should('have.text', 'Paymaster Data')
           .next()
-          .should('have.text', '1234')
+          .should('have.text', '1,234')
       })
 
       it('should have Call Data', () => {

--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -558,7 +558,7 @@ const Tx = () => {
       field: t('paymaster_data'),
       content: paymasterData ? (
         <Tooltip title={paymasterData} placement="top">
-          <div className={styles.paymasterData}>{new BigNumber(paymasterData).toFormat()}</div>
+          <div className={styles.paymasterData}>{`0x${paymasterData}`}</div>
         </Tooltip>
       ) : (
         '-'

--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -1,4 +1,5 @@
 import type { GetStaticPaths, GetStaticProps } from 'next'
+import type { ReactNode } from 'react'
 import { useMemo, useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
@@ -287,10 +288,8 @@ const Tx = () => {
 
   const gasPrice = tx?.polyjuice?.gas_price
   const isGasless = gasPrice === '0'
-  const getGasPriceDisplayValue = (): string => {
-    return isGasless
-      ? 'Gasless'
-      : `${new BigNumber(gasPrice).dividedBy(10 ** PCKB_UDT_INFO.decimal).toFormat()} ${PCKB_UDT_INFO.symbol}`
+  const getGasPriceDisplayValue = (): ReactNode => {
+    return isGasless ? 'Gasless' : <Amount amount={gasPrice} udt={PCKB_UDT_INFO} showSymbol />
   }
 
   const fromAddrDisplay = getAddressDisplay(tx?.from_account)
@@ -518,27 +517,26 @@ const Tx = () => {
     {
       field: t('call_contract'),
       content: tx?.polyjuice?.call_contract ? (
-        <HashLink label={tx.polyjuice.call_contract} href={`/address/${tx.polyjuice.call_contract}`} />
+        <ResponsiveHash label={tx.polyjuice.call_contract} href={`/address/${tx.polyjuice.call_contract}`} />
       ) : (
         '-'
       ),
     },
-    { field: t('call_gas_limit'), content: tx?.polyjuice?.call_gas_limit || '-' },
-    { field: t('verification_gas_limit'), content: tx?.polyjuice?.verification_gas_limit || '-' },
+    { field: t('call_gas_limit'), content: new BigNumber(tx?.polyjuice?.call_gas_limit).toFormat() || '-' },
+    {
+      field: t('verification_gas_limit'),
+      content: new BigNumber(tx?.polyjuice?.verification_gas_limit).toFormat() || '-',
+    },
     {
       field: t('paymaster'),
-      content: paymaster ? <HashLink label={paymaster} href={`/address/${paymaster}`} /> : '-',
+      content: paymaster ? <ResponsiveHash label={paymaster} href={`/address/${paymaster}`} /> : '-',
       colSpan: 2,
     },
     {
       field: t('max_fee_per_gas'),
       content: tx?.polyjuice?.max_fee_per_gas ? (
         <span className={styles.gasFee}>
-          <Amount
-            amount={`${new BigNumber(tx.polyjuice.max_fee_per_gas).times(new BigNumber(tx.polyjuice.max_fee_per_gas))}`}
-            udt={PCKB_UDT_INFO}
-            showSymbol
-          />
+          <Amount amount={tx.polyjuice.max_fee_per_gas} udt={PCKB_UDT_INFO} showSymbol />
         </span>
       ) : (
         '-'
@@ -549,13 +547,7 @@ const Tx = () => {
       ddClassName: styles.priorityGasFee,
       content: tx?.polyjuice?.max_priority_fee_per_gas ? (
         <span className={styles.gasFee}>
-          <Amount
-            amount={`${new BigNumber(tx.polyjuice.max_priority_fee_per_gas).times(
-              new BigNumber(tx.polyjuice.max_priority_fee_per_gas),
-            )}`}
-            udt={PCKB_UDT_INFO}
-            showSymbol
-          />
+          <Amount amount={tx.polyjuice.max_priority_fee_per_gas} udt={PCKB_UDT_INFO} showSymbol />
         </span>
       ) : (
         '-'
@@ -566,7 +558,7 @@ const Tx = () => {
       field: t('paymaster_data'),
       content: paymasterData ? (
         <Tooltip title={paymasterData} placement="top">
-          <div className={styles.paymasterData}>{paymasterData}</div>
+          <div className={styles.paymasterData}>{new BigNumber(paymasterData).toFormat()}</div>
         </Tooltip>
       ) : (
         '-'

--- a/pages/tx/styles.module.scss
+++ b/pages/tx/styles.module.scss
@@ -30,13 +30,10 @@
     }
   }
 
-  .priorityGasFee {
-    margin-left: -4px !important;
-  }
-
   .paymasterData {
     text-overflow: ellipsis;
     overflow: hidden;
+    width: min-content;
   }
 
   a {
@@ -46,7 +43,7 @@
   dl[role='listitem'] {
     dt {
       @media screen and (min-width: 1024px) {
-        flex-basis: 168px !important;
+        flex-basis: 172px !important;
       }
     }
     dd {


### PR DESCRIPTION
resolve https://github.com/Magickbase/godwoken_explorer/issues/1296

tx page:
- display `Gas Price` decimal place like `Fee`
- align `Max Priority Fee Per Gas` and `Max Fee Per Gas`
- `Max Fee Per Gas` `Max Priority Fee Per Gas` `Call Gas Limit` `Verification Gas Limit` `Paymaster Data` show number 
- mobile responsive hash display

<img width="824" alt="image" src="https://user-images.githubusercontent.com/32790369/216609294-fac87bee-067e-4eef-89d0-ee4890563c5e.png">

<img width="419" alt="image" src="https://user-images.githubusercontent.com/32790369/216609461-5232cfe7-8346-4f1e-98cd-a26e28e9decf.png">

