### PR TITLE
feat: add an amount field to specify pCKB sent along with a tx

### DIFF
--- a/components/ContractInfo/index.tsx
+++ b/components/ContractInfo/index.tsx
@@ -2,6 +2,7 @@ import type { PolyjuiceContract as PolyjuiceContractProps } from 'components/Acc
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'next-i18next'
 import NextLink from 'next/link'
+import { utils } from 'ethers'
 import OpenInNewIcon from 'assets/icons/open-in-new.svg'
 import ExpandIcon from 'assets/icons/expand.svg'
 import { currentChain as targetChain } from 'utils'
@@ -149,7 +150,8 @@ const ContractInfo: React.FC<{ address: string; contract: PolyjuiceContractProps
     form.setAttribute(LOADING_ATTRIBUTE, 'true')
 
     try {
-      const result = await method(...params)
+      const pCKB = form.querySelector<HTMLInputElement>('input[name=pCKB]')?.value ?? '0'
+      const result = await method(...params, { value: utils.parseEther(pCKB) })
       if (tabIdx === 2) {
         const elm = resInputList[0]
         if (elm) {
@@ -340,7 +342,7 @@ const ContractInfo: React.FC<{ address: string; contract: PolyjuiceContractProps
           ) : null}
           <div className={styles.methodGroupTitle}>Non-payable and Payable</div>
           {Object.keys(writeMethods).map(signature => {
-            const { inputs = [], outputs = [] } = contract.interface.functions[signature] ?? {}
+            const { inputs = [], outputs = [], payable } = contract.interface.functions[signature] ?? {}
             return (
               <details key={signature}>
                 <summary>
@@ -362,6 +364,12 @@ const ContractInfo: React.FC<{ address: string; contract: PolyjuiceContractProps
                         </fieldset>
                       )
                     })}
+                    {payable ? (
+                      <fieldset key="pCKB">
+                        <label>pCKB</label>
+                        <input name="pCKB" title="pCKB" placeholder={t('pckb_send_along_with_tx')} />
+                      </fieldset>
+                    ) : null}
                     <div className={styles.response}>Response</div>
                     <fieldset>
                       <label>Txn Hash</label>

--- a/public/locales/en-US/account.json
+++ b/public/locales/en-US/account.json
@@ -92,5 +92,6 @@
   "erc721Assets": "ERC 721 Assets",
   "erc1155Assets": "ERC 1155 Assets",
   "erc20Assets": "ERC 20 Assets",
-  "invalidAddress": "*Invalid address format"
+  "invalidAddress": "*Invalid address format",
+  "pckb_send_along_with_tx": "Send along with the transaction"
 }

--- a/public/locales/zh-CN/account.json
+++ b/public/locales/zh-CN/account.json
@@ -92,5 +92,6 @@
   "erc721Assets": "ERC 721 资产",
   "erc1155Assets": "ERC 1155 资产",
   "erc20Assets": "ERC 20 资产",
-  "invalidAddress": "*无效的地址格式"
+  "invalidAddress": "*无效的地址格式",
+  "pckb_send_along_with_tx": "与交易一起发送"
 }


### PR DESCRIPTION
This PR adds an `pCKB` field to specify the `pCKB` sent along with a transaction when the method of a contract is marked as `payable`

![image](https://user-images.githubusercontent.com/7271329/219387625-040007cf-2ebf-4855-8292-b4be289cfb50.png)

Ref: https://github.com/Magickbase/godwoken_explorer/issues/1324