### PR TITLE
fix: filter metadata files out of source code

### DIFF
--- a/components/ContractInfo/index.tsx
+++ b/components/ContractInfo/index.tsx
@@ -216,7 +216,10 @@ const ContractInfo: React.FC<{ address: string; contract: PolyjuiceContractProps
           {contract_source_code ? (
             <>
               {Array.isArray(sourcify_metadata) ? (
-                sourcify_metadata.slice(1).map(code => {
+                sourcify_metadata.map(code => {
+                  if (!code.name.endsWith('.sol')) {
+                    return null
+                  }
                   return (
                     <div className={styles.sourceCode} key={code.name}>
                       <div className={styles.title}>


### PR DESCRIPTION
This commit fixes the source code list by filtering files those not ending with .sol, so only solidity files will be displayed

Before: 
![image](https://user-images.githubusercontent.com/7271329/231334548-278e2305-761d-41d9-8536-b27a4d81f61b.png)

After:
![image](https://user-images.githubusercontent.com/7271329/231334582-d14eb935-02d9-4ed0-864a-3956ea0524b6.png)

Contract address on testnet: 0xf8f6173ae4a352de056e278ebc940af972b71de9