### PR TITLE
fix:layout of tooltip is improper

### DIFF
--- a/styles/tooltip.scss
+++ b/styles/tooltip.scss
@@ -23,7 +23,7 @@
     background-color: var(--tooltip-background-color);
     color: var(--tooltip-font-color);
     user-select: text;
-    white-space: normal;
+    white-space: nowrap;
     text-align: center;
     display: none;
 


### PR DESCRIPTION
What problem does this PR solve?
------
As title.

<img width="600" alt="image" src="https://github.com/Magickbase/godwoken-explorer-ui/assets/22511289/1edcc2d1-d13b-495b-899f-778b91582176">

<img width="600" alt="image" src="https://github.com/Magickbase/godwoken-explorer-ui/assets/22511289/bfe94b9f-2f81-4290-b578-47ec88d6366d">


Ref: https://github.com/Magickbase/godwoken_explorer/issues/1428


Check List
------
1、List
2、Detail

### Test
e2e Test
### Task
none
