### PR TITLE
fix: SubDID is resolved to its parent DataDID page

### DIFF
--- a/components/AccountOverview/index.tsx
+++ b/components/AccountOverview/index.tsx
@@ -351,7 +351,13 @@ const AccountOverview: React.FC<AccountOverviewProps & { refetch: () => Promise<
 
   const getInfoBlock = account => {
     const { type } = account
-    const domain = account?.bit_alias
+    let domain = account?.bit_alias
+
+    if (domain && domain.includes('#')) {
+      const [domainName, subDomain] = domain.split('#')
+
+      domain = `${subDomain.split('.')[0]}.${domainName}.bit`
+    }
 
     const blockMap = {
       [`${GraphQLSchema.AccountType.MetaContract}`]: <MetaContract {...(account.script as MetaContract['script'])} />,

--- a/components/TitleWithDomain/styles.module.scss
+++ b/components/TitleWithDomain/styles.module.scss
@@ -23,7 +23,7 @@
     font-weight: 400;
     display: flex;
     align-items: center;
-    margin-right: 4px;
+    padding-right: 4px;
   }
   .domain {
     display: flex;


### PR DESCRIPTION
What problem does this PR solve?
------
The bit domian like `ckbees#run.bit` will be link to `https://data.did.id/run.ckbees.bit`


Ref: https://github.com/Magickbase/godwoken_explorer/issues/1465

Check List
------


### Test
e2e Test

